### PR TITLE
Layer supports slicing and iterating

### DIFF
--- a/tensorlayer/layers/core.py
+++ b/tensorlayer/layers/core.py
@@ -439,7 +439,9 @@ class Layer(object):
         return "  Last layer is: %s (%s) %s" % (self.__class__.__name__, self.name, self.outputs.get_shape().as_list())
 
     def __getitem__(self, key):
+        set_name_reuse(True)
         net_new = Layer(self.inputs, name=self.name)
+        set_name_reuse(set_keep['name_reuse'])  # set back
         net_new.outputs = self.outputs[key]
 
         net_new.all_layers = list(self.all_layers[:-1])

--- a/tensorlayer/layers/core.py
+++ b/tensorlayer/layers/core.py
@@ -436,10 +436,30 @@ class Layer(object):
         return n_params
 
     def __str__(self):
-        # logging.info("\nIt is a Layer class")
-        # self.print_params(False)
-        # self.print_layers()
-        return "  Last layer is: %s" % self.__class__.__name__
+        return "  Last layer is: %s (%s) %s" % (self.__class__.__name__, self.name, self.outputs.get_shape().as_list())
+
+    def __getitem__(self, key):
+        net_new = Layer(self.inputs, name=self.name)
+        net_new.outputs = self.outputs[key]
+
+        net_new.all_layers = list(self.all_layers[:-1])
+        net_new.all_layers.append(net_new.outputs)
+        net_new.all_params = list(self.all_params)
+        net_new.all_drop = dict(self.all_drop)
+        return net_new
+
+    def __setitem__(self, key):
+        raise NotImplementedError("%s: __setitem__" % self.name)
+
+    def __delitem__(self, key):
+        raise NotImplementedError("%s: __delitem__" % self.name)
+
+    def __iter__(self):
+        for x in self.all_layers:
+            yield x
+
+    def __len__(self):
+        return len(self.all_layers)
 
 
 class InputLayer(Layer):

--- a/tensorlayer/layers/core.py
+++ b/tensorlayer/layers/core.py
@@ -450,7 +450,8 @@ class Layer(object):
         net_new.all_drop = dict(self.all_drop)
         return net_new
 
-    def __setitem__(self, key):
+    def __setitem__(self, key, item):
+        # self.outputs[key] = item
         raise NotImplementedError("%s: __setitem__" % self.name)
 
     def __delitem__(self, key):


### PR DESCRIPTION
Given the following model:
```python
>>> x = tf.placeholder("float32", [None, 100])
>>> n = tl.layers.InputLayer(x, name='in')
>>> n = tl.layers.DenseLayer(n, 80, name='d1')
>>> n = tl.layers.DenseLayer(n, 80, name='d2')
>>> print(n)
... Last layer is: DenseLayer (d2) [None, 80]
```

The outputs can be sliced as follow:
```python
>>> n2 = n[:30]
>>> print(n2)
... Last layer is: Layer (d2) [None, 30]
```

The outputs of all layers can be iterated as follow:
```python
>>> for l in n:
>>>    print(l)
... Tensor("d1/Identity:0", shape=(?, 80), dtype=float32)
... Tensor("d2/Identity:0", shape=(?, 80), dtype=float32)
```