### PR TITLE
fix the bug of tensorlayer.utils.predict. issues of #288

### DIFF
--- a/tensorlayer/utils.py
+++ b/tensorlayer/utils.py
@@ -325,7 +325,7 @@ def predict(sess, network, X, x, y_op, batch_size=None):
             if result is None:
                 result = result_a
             else:
-                result = np.vstack((result, result_a))  # TODO: https://github.com/tensorlayer/tensorlayer/issues/288
+                result = np.hstack((result, result_a))  # TODO: https://github.com/tensorlayer/tensorlayer/issues/288
         if result is None:
             if len(X) % batch_size != 0:
                 dp_dict = dict_to_one(network.all_drop)
@@ -343,7 +343,7 @@ def predict(sess, network, X, x, y_op, batch_size=None):
                 }
                 feed_dict.update(dp_dict)
                 result_a = sess.run(y_op, feed_dict=feed_dict)
-                result = np.vstack((result, result_a))  # TODO: https://github.com/tensorlayer/tensorlayer/issues/288
+                result = np.hstack((result, result_a))  # TODO: https://github.com/tensorlayer/tensorlayer/issues/288
         return result
 
 


### PR DESCRIPTION
fix the bug of issues #288 

I have fix the bug and the test is as follow:

The relations between data_size and batch_size  can be classified into three types:
1. batch_size == data_size; 
2. batch_size < data_size 
3. batch_size > data_size. 

And the second can be further classified into two types: 

(a)data_size % batch_size ==0. 

(b)data_size % batch_size != 0;

So the test data is as follow:

| types | data_size | batch_size|pred_size|pass?|
|-|-|-|-|-|
| 1    |  100  |  100 |  100 |  YES |
| 2.a | 100   |     10     | 100  | YES  |
| 2.b | 100   |     51     |  100 |  YES |
| 3    |  100  |     101    |  100 | YES  |

