### PR TITLE
tl.iterate.minibatch support list with shuffle

### DIFF
--- a/tensorlayer/iterate.py
+++ b/tensorlayer/iterate.py
@@ -59,7 +59,10 @@ def minibatches(inputs=None, targets=None, batch_size=None, shuffle=False):
             excerpt = indices[start_idx:start_idx + batch_size]
         else:
             excerpt = slice(start_idx, start_idx + batch_size)
-        yield inputs[excerpt], targets[excerpt]
+        if (isinstance(inputs, list) or isinstance(targets, list)) and (shuffle == True):
+            yield [inputs[i] for i in excerpt], [targets[i] for i in excerpt]  # zsdonghao: for list indexing when shuffle==True
+        else:
+            yield inputs[excerpt], targets[excerpt]
 
 
 def seq_minibatches(inputs, targets, batch_size, seq_length, stride=1):

--- a/tensorlayer/models/mobilenetv1.py
+++ b/tensorlayer/models/mobilenetv1.py
@@ -56,7 +56,7 @@ class MobileNetV1(Layer):
     >>> # restore pre-trained parameters
     >>> cnn.restore_params(sess)
     >>> # train your own classifier (only update the last layer)
-    >>> train_params = tl.layers.get_variables_with_name('output')
+    >>> train_params = tl.layers.get_variables_with_name('out')
 
     Reuse model
 

--- a/tensorlayer/models/vgg16.py
+++ b/tensorlayer/models/vgg16.py
@@ -231,7 +231,7 @@ class VGG16Base(object):
 
 
 class VGG16(VGG16Base):
-    """Pre-trained VGG-16 Model.
+    """Pre-trained VGG-16 model.
 
     Parameters
     ------------


### PR DESCRIPTION
This API works well for numpy array input, but when inputs are list, and we shuffle the data, we can't index the elements in a list with a list.