### PR TITLE
ProgressBar added for dataset download. Now stops bombarding console

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 numpy
+progressbar2==3.37.0
 scipy
 scikit-image
 matplotlib

--- a/tensorlayer/files.py
+++ b/tensorlayer/files.py
@@ -9,6 +9,7 @@ import sys
 import tarfile
 import time
 import zipfile
+import progressbar
 
 import numpy as np
 import tensorflow as tf
@@ -2030,14 +2031,17 @@ def maybe_download_and_extract(filename, working_directory, url_source, extract=
 
     # We first define a download function, supporting both Python 2 and 3.
     def _download(filename, working_directory, url_source):
-        def _dlProgress(count, blockSize, totalSize):
+
+        progress_bar = progressbar.ProgressBar()
+
+        def _dlProgress(count, blockSize, totalSize, pbar=progress_bar):
             if (totalSize != 0):
-                totalBlocks = math.ceil(float(totalSize) / float(blockSize))
-                percent = float(count) / float(totalBlocks) * 100.0
-                # https://www.quora.com/How-can-I-delete-the-last-printed-line-in-Python-language
-                sys.stdout.write('\033[F')  # back to previous line
-                sys.stdout.write('\033[K')  # clear line
-                sys.stdout.write('Downloading %s...%g%%\n' % (filename, percent))
+
+                if not pbar.max_value:
+                    totalBlocks = math.ceil(float(totalSize) / float(blockSize))
+                    pbar.max_value = int(totalBlocks)
+
+                pbar.update(count, force=True)
 
         if sys.version_info[0] == 2:
             from urllib import urlretrieve


### PR DESCRIPTION
Quick fix to removed console being bombarded by the download of a dataset (e.g. MNIST).

Can be tested like this:
```python
import tensorlayer as tl
X_train, y_train, X_val, y_val, X_test, y_test = tl.files.load_mnist_dataset()
```

Be careful to reinstall the library properly if you want to test before the next release
```shell
pip install -r requirements.txt
pip install -e .[test]
```

### Result

![tensorlayer](https://user-images.githubusercontent.com/10923599/38878652-b8735276-4261-11e8-892c-4025ba745b26.gif)