### PR TITLE
keep_dims is deprecated, use keepdims instead

### DIFF
--- a/tensorlayer/layers/core.py
+++ b/tensorlayer/layers/core.py
@@ -862,7 +862,7 @@ class AverageEmbeddingInputlayer(Layer):
             sentence_lengths = tf.count_nonzero(
                 masks,
                 axis=1,
-                keep_dims=True,
+                keepdims=True,
                 # dtype=tf.float32,
                 dtype=LayersConfig.tf_dtype,
                 name='sentence_lengths',


### PR DESCRIPTION
### Checklist
- In `AverageEmbeddingInputlayer`, keep_dims is deprecated, use keep dims instead https://github.com/tensorlayer/tensorlayer/issues/498
