### PR TITLE
Travis build from fork fixed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,11 @@ env:
 
   ### === GITHUB_PERSONAL_TOKEN === ###
   ## To update: travis encrypt GITHUB_PERSONAL_TOKEN=################################
-  - secure: "GmdokEVWFS4LlSIdhfYvET+53hcuN9gN5gbhYduWkvyqvCJnP5PENzxdDz6Y3EJCSXxfKTT+jBLmJkgOElgeWxyAEa+wGj3jJzpjFD8BEcxIf5mNsyJ2LryzecFoKjcCR7viid14GDEYSeA3UB0MgKgitm9rMmcQ2W9RLJfAmTfGRQ+kMwhM7GTeFc5c99YL7DW7AUFSbiAac/k50AMx2j9KNT1JAGhDoc5yVTdVvtKrdtuCZUa82q4Cm/h4IEd6BbNrcImYyxQ814LHCrHWBi9jmuc+UxqvsTH1ErNapIObz490ri3DmZg+LUrH5dIuhSa5HGqZjob6tKG6XCKFWOuv9E73+URDitJllXHc1qSP/K61SMmsQrE2FnaxVjxpQCOcqueRMKszwH5/k3UoGbUPWsBFwbBznXrnHO/DNHAgL9XwOFP6biPP8TKp2ReX41YwcU6sbiYb7naGWo3Dhe+yEB9wBGOwuGHipDQm9R4SSIJgjpdc642KjcEMQqb3yL7DWpOmItXMxoGNM+X93kU4u4u1tGgq1yxnhEk6VG2l/yI6A2QOVIPyOu+L9FkZL3mrl9mbUeBKr/SHX4CTFODi5io8D0lqwNSRZrmi/GGWh2glbNnTapD67UnTnsh/6LE2YiSqGteH47EByb9V4ykrjfdv5EZhyJNwI7jYPDw="
+  - secure: "kMxg4WfTwhnYMD7WjYk71vgw7XlShPpANauKzfTL6oawDrpQRkBUai4uQwiL3kXVBuVv9rKKKZxxnyAm05iB5wGasPDhlFA1DPF0IbyU3pwQKlw2Xo5qtHdgxBnbms6JJ9z5b+hHCVg+LXYYeUw5qG01Osg5Ue6j1g2juQQHCod00FNuo3fe8ah/Y10Rem6CigH8ofosCrTvN2w1GaetJwVehRYf8JkPC6vQ+Yk8IIjHn2CaVJALbhuchVblxwH0NXXRen915BVBwWRQtsrvEVMXKu7A8sMHmvPz1u3rhXQfjpF2KeVOfy1ZnyiHcLE2HgAPuAGh4kxZAAA8ovmcaCbv8m64bm72BrQApSbt6OEtR9L1UeUwdEgi54FH1XFOHQ9dA6CpiGCyk3wAJZqO0/PkNYVLfb4gPLvnvBRwYBaPgUPvVNhidFu/oODENZmcf8g9ChtuC1GT70EYlVwhgDGqUY7/USZCEvIPe81UToqtIKgcgA+Is51XindumJVMiqTsjgdqeC/wZcw+y37TAjIvvXbtYxeqIKv9zh1JuZppqUhnf+OhI+HHFaY4iu7lQTs3C0WmoLskZAp9srwRtifnVFFkdYzngmPaSjWyko2qiS0cTdFJQB/ljqmnJdksacbv5OOa0Q4qZef/hW774nVx105FlkAIk70D2b5l2pA="
 
-  # DANGER_GITHUB_API_TOKEN
-  - secure: "Gwj32xBnwb4+HsNc2vMaH3oFm4eyv/a8a0vz+R0G5KxBCZi/pKJIlkJKA2ECvKAqcEjneVJUXL426u8rhbezvcl+duQS5sm8VlZx79BDKoQ7lkKBbTllXS1wNlM9YE8OI1QdSjCTVzR9AH65bDWIdxDoKqIUKbG3iOIEe57xeMgxHyHXbUe5b1hBByszILnFJv6NB+dYVBnJp31PJ1ts+8fiGoxAOrUq7LlnG9EzfMjKEmlOHJL++igRsGIQgEUfdDyD+6uGRVcj6MxJ8gX3jMsSoiwUk6Pfp3Q7+BcHjGc3VZNjJ4u3SC/eZ5chDiwhuK+h985GFvEo/Q3fwUwFK0L40iX/J8asp8J8bfL+ygax+BkU1ivr678f5WxwB+Lwzkwmq1u/UZH3tiqZ/q1qFs4hnuxceBWh4dSmtYcxKWsVV2dRXQpoA7ap3hlRptUE3KK2NvsyOdxo4gqCGGxduwyc71z6eZKjXMCXumz6L+Wj34XEDGvA4BWmnWetpc2KywfTFm/2UshxJOXD5RWOkYOGgWojdDQ5n90l16oyVq+23bDXOtKPSQ0UDbleh0u97atDnpY08JLFudNf4W4CK+IZFsu608FwfMy0TPMFPd/kYEcz+dOTluNxO1lSUxcFItmM/05NboEsuYMnreHoFJfNNxiHMeF/kb4DuAEG2jQ="
+  ### === DANGER_GITHUB_API_TOKEN === ###
+  ## To update: travis encrypt DANGER_GITHUB_API_TOKEN=################################
+  - secure: "T7uFuuOYciFHnz+5C+XhN7yhCc56tyC9a9eaiaZQExEO7UGazkGUU+S9OsJdfktnQuhoKPs+x7tCSDi+HXcEtjPOeKCgCGaC45LDEpeTm4emuRY93wXF9zOmwBMipsKOac/XGYtnrXwnlFLvkJo79TlPMPFNMeSvoubNjZhtc7bIXcsi7BxG89D/k3RPxXotGHy/bKHums7td8McwXrdbUSSLXBzydrzmFuo4b2DLpKmD/BSHkiHAFqxO5GwZQ/FFUdnaFwAkTJnpk6WBTlhfY0FyrmqthFKgdJtsvuFYIarSifyo1+lHo502tBYlinRJ3h8gh56TtgRyD4sqRRCv9JgjjzU378TO3ylmCcVxxvp4Xb0c45I1gLoZPdMUZMuCCrpT73bR/cJi1BNpYxWnKEDmRJpV92hr4QAIvJI4v2m9/lE44kESdKGw9c4P8TxaTtWSf+0w3kbJSJTzhgAJubYRLTQV/lTg/KY6zHBDRq5Mnv3+96XpQQldZbVrrCoiisR5wbdMfIk/1DJkHaYNFVGQy+RT6IG2fuPTSdRuO56NiCcnH6SVqDtGkjVbGynw2/2KlPvi/heuDW/g+OVtkZ0Hcfm+ntJT89GE0CeUPvaactJe11N+UuJo3150fu9zaOLBGtghgQe+u9cwjb4YA4Y/6yJSk0ZzbgxwE5C1Rc="
 
 
 install:
@@ -32,7 +33,12 @@ script:
   # units test
   # https://docs.pytest.org/en/latest/
   - pytest  
-  - if [ "$TRAVIS_PYTHON_VERSION" == '3.6' ] && [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then bundle install && bundle exec danger; fi
+  
+  # Only run under the following conditions:
+  # - Python is version 3.6 => Do not run it 3 three times for each build
+  # - It is a PR build, not necessary in Push Commits.
+  # - Make sure the variable `DANGER_GITHUB_API_TOKEN` is defined, when a PR is sent from a fork, encrypted vars are not defined, thus the build would be failing.
+  - if [ "$TRAVIS_PYTHON_VERSION" == '3.6' ] && [ "$TRAVIS_EVENT_TYPE" = "pull_request" ] && [ "$DANGER_GITHUB_API_TOKEN" ]; then bundle install && bundle exec danger; fi
 
 before_deploy:
   - python setup.py sdist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `Removed` for now removed features.
 * `Fixed` for any bug fixes.
 * `Security` in case of vulnerabilities.
+* `Contributors` to thank the contributors that worked on this PR.
 
 ============== How To Update The Changelog for a New Release ==============
 
@@ -36,6 +37,23 @@ To release a new version, please update the changelog as followed:
 -->
 
 ## [Unreleased]
+
+### Added
+- Danger CI has been added to enforce the update of the changelog by @lgarithm and @DEKHTIARJonathan
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+### Contributors
+
+
 
 ## [1.8.5] - 2018-05-09
 
@@ -50,6 +68,9 @@ To release a new version, please update the changelog as followed:
 ### Fixed
 
 ### Security
+
+### Contributors
+@zsdonghao @luomai @DEKHTIARJonathan @2wins @auroua
 
 [Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/1.8.5...master
 [1.8.5]: https://github.com/tensorlayer/tensorlayer/compare/1.8.4...1.8.5


### PR DESCRIPTION
The build were not working when it was running from a fork repository.
This PR aims to bypass the build from Danger when it is from a forked repo.

We need to make sure **by hand** to check that the Changelog have been updated when we merge a PR from a forked repo.

Please merge ASAP ;)

I didn't updated the Changelog because it's a fix of a newly introduced bugged.Some new textSome new text