### PR TITLE
`tl.alphas` and `tl.alphas_like` added following the tf.ones/zeros and tf.zeros_like/ones_like

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,8 @@ To release a new version, please update the changelog as followed:
 ## [Unreleased]
 
 ### Added
-- `tl.alphas` and `tl.alphas_like` added following the tf.ones/zeros and tf.zeros_like/ones_like (by @DEKHTIARJonathan in #580)
+- API:
+  - `tl.alphas` and `tl.alphas_like` added following the tf.ones/zeros and tf.zeros_like/ones_like (by @DEKHTIARJonathan in #580)
 - Tutorials:
   - `tutorial_tfslim` has been introduced to show how to use `SlimNetsLayer` (by @2wins in #560).
 - Test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,10 +69,12 @@ To release a new version, please update the changelog as followed:
 ## [Unreleased]
 
 ### Added
+- `tl.alphas` and `tl.alphas_like` added following the tf.ones/zeros and tf.zeros_like/ones_like (by @DEKHTIARJonathan in #580)
 - Tutorials:
   - `tutorial_tfslim` has been introduced to show how to use `SlimNetsLayer` (by @2wins in #560).
 - Test:
   - `Layer_DeformableConvolution_Test` added to reproduce issue #572 with deformable convolution (by @DEKHTIARJonathan in #573)
+  - `Array_Op_Alphas_Test` and `Array_Op_Alphas_Like_Test` added to test `tensorlayer/array_ops.py` file (by @DEKHTIARJonathan in #580)
 - CI Tool:
   - Danger CI has been added to enforce the update of the changelog (by @lgarithm and @DEKHTIARJonathan in #563)
   - https://github.com/apps/stale/ added to clean stale issues (by @DEKHTIARJonathan in #573)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,18 +42,19 @@ method, this part of the documentation is for you.
 .. toctree::
   :maxdepth: 2
 
-  modules/layers
-  modules/cost
-  modules/prepro
-  modules/iterate
-  modules/utils
-  modules/nlp
-  modules/rein
-  modules/files
-  modules/visualize
   modules/activation
-  modules/models
+  modules/array_ops
+  modules/cost
   modules/distributed
+  modules/files
+  modules/iterate
+  modules/models
+  modules/nlp
+  modules/layers
+  modules/prepro
+  modules/rein
+  modules/utils
+  modules/visualize
   modules/db
 
 

--- a/docs/modules/array_ops.rst
+++ b/docs/modules/array_ops.rst
@@ -1,0 +1,20 @@
+API - Array Operations
+======================
+
+.. automodule:: tensorlayer.array_ops
+
+.. autosummary::
+
+   alphas
+   alphas_like
+
+Tensorflow Tensor Operations
+----------------------------
+
+tl.alphas
+^^^^^^^^^
+.. autofunction:: alphas
+
+tl.alphas_like
+^^^^^^^^^^^^^^
+.. autofunction:: alphas_like

--- a/tensorlayer/__init__.py
+++ b/tensorlayer/__init__.py
@@ -7,6 +7,7 @@ try:
     import tensorflow
 
     from . import activation
+    from .array_ops import alphas, alphas_like
     from . import cost
     from . import files
     from . import iterate

--- a/tensorlayer/array_ops.py
+++ b/tensorlayer/array_ops.py
@@ -20,17 +20,23 @@ def alphas(shape, alpha_value, name=None):
     """Creates a tensor with all elements set to `alpha_value`.
     This operation returns a tensor of type `dtype` with shape `shape` and all
     elements set to alpha.
-    For example:
-    ```python
-    tl.alphas([2, 3], tf.int32)  # [[alpha, alpha, alpha], [alpha, alpha, alpha]]
-    ```
-    Args:
-    shape: A list of integers, a tuple of integers, or a 1-D `Tensor` of type
-      `int32`.
-    alpha_value: The value used to fill the resulting `Tensor`.
-    name: A name for the operation (optional).
-    Returns:
+
+    Parameters
+    ----------
+    shape: A list of integers, a tuple of integers, or a 1-D `Tensor` of type `int32`.
+        The shape of the desired tensor
+    alpha_value: `float32`, `float64`, `int8`, `uint8`, `int16`, `uint16`, int32`, `int64`
+        The value used to fill the resulting `Tensor`.
+    name: str
+        A name for the operation (optional).
+
+    Returns
+    -------
     A `Tensor` with all elements set to alpha.
+
+    Examples
+    --------
+    >>> tl.alphas([2, 3], tf.int32)  # [[alpha, alpha, alpha], [alpha, alpha, alpha]]
     """
 
     with ops.name_scope(name, "alphas", [shape]) as name:
@@ -61,24 +67,30 @@ def alphas(shape, alpha_value, name=None):
 
 def alphas_like(tensor, alpha_value, name=None, optimize=True):
     """Creates a tensor with all elements set to `alpha_value`.
-  Given a single tensor (`tensor`), this operation returns a tensor of the same
-  type and shape as `tensor` with all elements set to `alpha_value`.
-  For example:
-  ```python
-  tensor = tf.constant([[1, 2, 3], [4, 5, 6]])
-  tl.alphas_like(tensor, 0.5)  # [[0.5, 0.5, 0.5], [0.5, 0.5, 0.5]]
-  ```
-  Args:
-    tensor: A `Tensor`.
-    alpha_value: A type for the returned `Tensor`. Must be `float32`, `float64`,
-      `int8`, `uint8`, `int16`, `uint16`, int32`, `int64`,
-      `complex64`, `complex128` or `bool`.
-    name: A name for the operation (optional).
-    optimize: if true, attempt to statically determine the shape of 'tensor'
-    and encode it as a constant.
-  Returns:
+    Given a single tensor (`tensor`), this operation returns a tensor of the same
+    type and shape as `tensor` with all elements set to `alpha_value`.
+
+    Parameters
+    ----------
+    tensor: tf.Tensor
+        The Tensorflow Tensor that will be used as a template.
+    alpha_value: `float32`, `float64`, `int8`, `uint8`, `int16`, `uint16`, int32`, `int64`
+        The value used to fill the resulting `Tensor`.
+    name: str
+        A name for the operation (optional).
+    optimize: bool
+        if true, attempt to statically determine the shape of 'tensor' and encode it as a constant.
+
+    Returns
+    -------
     A `Tensor` with all elements set to `alpha_value`.
-  """
+
+    Examples
+    --------
+    >>> tensor = tf.constant([[1, 2, 3], [4, 5, 6]])
+    >>> tl.alphas_like(tensor, 0.5)  # [[0.5, 0.5, 0.5], [0.5, 0.5, 0.5]]
+    """
+
     with ops.name_scope(name, "alphas_like", [tensor]) as name:
         tensor = ops.convert_to_tensor(tensor, name="tensor")
 

--- a/tensorlayer/array_ops.py
+++ b/tensorlayer/array_ops.py
@@ -1,0 +1,118 @@
+#! /usr/bin/python
+# -*- coding: utf-8 -*-
+"""A file containing functions related to array manipulation."""
+
+import tensorflow as tf
+
+from tensorflow.python.eager import context
+from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
+from tensorflow.python.framework import tensor_shape
+from tensorflow.python.framework.constant_op import constant
+from tensorflow.python.framework.ops import convert_to_tensor
+from tensorflow.python.ops.array_ops import shape_internal
+from tensorflow.python.ops.gen_array_ops import fill
+from tensorflow.python.ops.gen_array_ops import reshape
+
+__all__ = [
+    'alphas',
+    'alphas_like'
+]
+
+
+def alphas(shape, alpha_value, name=None):
+    """Creates a tensor with all elements set to alpha.
+    This operation returns a tensor of type `dtype` with shape `shape` and all
+    elements set to alpha.
+    For example:
+    ```python
+    tf.alphas([2, 3], tf.int32)  # [[alpha, alpha, alpha], [alpha, alpha, alpha]]
+    ```
+    Args:
+    shape: A list of integers, a tuple of integers, or a 1-D `Tensor` of type
+      `int32`.
+    dtype: The type of an element in the resulting `Tensor`.
+    name: A name for the operation (optional).
+    Returns:
+    A `Tensor` with all elements set to alpha.
+    """
+
+    with ops.name_scope(name, "alphas", [shape]) as name:
+
+        alpha_tensor = convert_to_tensor(alpha_value)
+        alpha_dtype = dtypes.as_dtype(alpha_tensor.dtype).base_dtype
+
+        if not isinstance(shape, ops.Tensor):
+            try:
+                shape = constant_op._tensor_shape_tensor_conversion_function(tensor_shape.TensorShape(shape))
+            except (TypeError, ValueError):
+                shape = ops.convert_to_tensor(shape, dtype=dtypes.int32)
+
+        if not shape._shape_tuple():
+            shape = reshape(shape, [-1])  # Ensure it's a vector
+
+
+        try:
+          output = constant(alpha_value, shape=shape, dtype=alpha_dtype, name=name)
+
+        except (TypeError, ValueError) as e:
+            output = fill(shape, constant(alpha_value, dtype=alpha_dtype), name=name)
+
+        assert output.dtype.base_dtype == alpha_dtype
+
+        return output
+
+
+def alphas_like(tensor, alpha_value, name=None, optimize=True):
+  """Creates a tensor with all elements set to `alpha_value`.
+  Given a single tensor (`tensor`), this operation returns a tensor of the same
+  type and shape as `tensor` with all elements set to 1. Optionally, you can
+  specify a new type (`dtype`) for the returned tensor.
+  For example:
+  ```python
+  tensor = tf.constant([[1, 2, 3], [4, 5, 6]])
+  tf.ones_like(tensor)  # [[1, 1, 1], [1, 1, 1]]
+  ```
+  Args:
+    tensor: A `Tensor`.
+    alpha_value: A type for the returned `Tensor`. Must be `float32`, `float64`,
+      `int8`, `uint8`, `int16`, `uint16`, int32`, `int64`,
+      `complex64`, `complex128` or `bool`.
+    name: A name for the operation (optional).
+    optimize: if true, attempt to statically determine the shape of 'tensor'
+    and encode it as a constant.
+  Returns:
+    A `Tensor` with all elements set to 1.
+  """
+  with ops.name_scope(name, "alphas_like", [tensor]) as name:
+    tensor = ops.convert_to_tensor(tensor, name="tensor")
+
+    if context.in_eager_mode():    #and dtype is not None and dtype != tensor.dtype:
+        ret = alphas(
+            shape_internal(tensor, optimize=optimize),
+            alpha_value=alpha_value,
+            name=name
+        )
+
+    else: # if context.in_graph_mode():
+
+        # For now, variant types must be created via zeros_like; as we need to
+        # pass the input variant object to the proper zeros callback.
+
+        if (optimize and tensor.shape.is_fully_defined()):
+            # We can produce a zeros tensor independent of the value of 'tensor',
+            # since the shape is known statically.
+            ret = alphas(tensor.shape, alpha_value=alpha_value, name=name)
+
+        # elif dtype is not None and dtype != tensor.dtype and dtype != dtypes.variant:
+        else:
+            ret = alphas(
+                shape_internal(tensor, optimize=optimize),
+                alpha_value=alpha_value,
+                name=name
+            )
+
+        ret.set_shape(tensor.get_shape())
+
+    return ret

--- a/tensorlayer/array_ops.py
+++ b/tensorlayer/array_ops.py
@@ -17,17 +17,17 @@ __all__ = ['alphas', 'alphas_like']
 
 
 def alphas(shape, alpha_value, name=None):
-    """Creates a tensor with all elements set to alpha.
+    """Creates a tensor with all elements set to `alpha_value`.
     This operation returns a tensor of type `dtype` with shape `shape` and all
     elements set to alpha.
     For example:
     ```python
-    tf.alphas([2, 3], tf.int32)  # [[alpha, alpha, alpha], [alpha, alpha, alpha]]
+    tl.alphas([2, 3], tf.int32)  # [[alpha, alpha, alpha], [alpha, alpha, alpha]]
     ```
     Args:
     shape: A list of integers, a tuple of integers, or a 1-D `Tensor` of type
       `int32`.
-    dtype: The type of an element in the resulting `Tensor`.
+    alpha_value: The value used to fill the resulting `Tensor`.
     name: A name for the operation (optional).
     Returns:
     A `Tensor` with all elements set to alpha.
@@ -61,12 +61,11 @@ def alphas(shape, alpha_value, name=None):
 def alphas_like(tensor, alpha_value, name=None, optimize=True):
     """Creates a tensor with all elements set to `alpha_value`.
   Given a single tensor (`tensor`), this operation returns a tensor of the same
-  type and shape as `tensor` with all elements set to 1. Optionally, you can
-  specify a new type (`dtype`) for the returned tensor.
+  type and shape as `tensor` with all elements set to `alpha_value`.
   For example:
   ```python
   tensor = tf.constant([[1, 2, 3], [4, 5, 6]])
-  tf.ones_like(tensor)  # [[1, 1, 1], [1, 1, 1]]
+  tl.alphas_like(tensor, 0.5)  # [[0.5, 0.5, 0.5], [0.5, 0.5, 0.5]]
   ```
   Args:
     tensor: A `Tensor`.
@@ -77,7 +76,7 @@ def alphas_like(tensor, alpha_value, name=None, optimize=True):
     optimize: if true, attempt to statically determine the shape of 'tensor'
     and encode it as a constant.
   Returns:
-    A `Tensor` with all elements set to 1.
+    A `Tensor` with all elements set to `alpha_value`.
   """
     with ops.name_scope(name, "alphas_like", [tensor]) as name:
         tensor = ops.convert_to_tensor(tensor, name="tensor")

--- a/tensorlayer/array_ops.py
+++ b/tensorlayer/array_ops.py
@@ -15,10 +15,7 @@ from tensorflow.python.ops.array_ops import shape_internal
 from tensorflow.python.ops.gen_array_ops import fill
 from tensorflow.python.ops.gen_array_ops import reshape
 
-__all__ = [
-    'alphas',
-    'alphas_like'
-]
+__all__ = ['alphas', 'alphas_like']
 
 
 def alphas(shape, alpha_value, name=None):
@@ -52,9 +49,8 @@ def alphas(shape, alpha_value, name=None):
         if not shape._shape_tuple():
             shape = reshape(shape, [-1])  # Ensure it's a vector
 
-
         try:
-          output = constant(alpha_value, shape=shape, dtype=alpha_dtype, name=name)
+            output = constant(alpha_value, shape=shape, dtype=alpha_dtype, name=name)
 
         except (TypeError, ValueError) as e:
             output = fill(shape, constant(alpha_value, dtype=alpha_dtype), name=name)
@@ -65,7 +61,7 @@ def alphas(shape, alpha_value, name=None):
 
 
 def alphas_like(tensor, alpha_value, name=None, optimize=True):
-  """Creates a tensor with all elements set to `alpha_value`.
+    """Creates a tensor with all elements set to `alpha_value`.
   Given a single tensor (`tensor`), this operation returns a tensor of the same
   type and shape as `tensor` with all elements set to 1. Optionally, you can
   specify a new type (`dtype`) for the returned tensor.
@@ -85,34 +81,26 @@ def alphas_like(tensor, alpha_value, name=None, optimize=True):
   Returns:
     A `Tensor` with all elements set to 1.
   """
-  with ops.name_scope(name, "alphas_like", [tensor]) as name:
-    tensor = ops.convert_to_tensor(tensor, name="tensor")
+    with ops.name_scope(name, "alphas_like", [tensor]) as name:
+        tensor = ops.convert_to_tensor(tensor, name="tensor")
 
-    if context.in_eager_mode():    #and dtype is not None and dtype != tensor.dtype:
-        ret = alphas(
-            shape_internal(tensor, optimize=optimize),
-            alpha_value=alpha_value,
-            name=name
-        )
+        if context.in_eager_mode():  #and dtype is not None and dtype != tensor.dtype:
+            ret = alphas(shape_internal(tensor, optimize=optimize), alpha_value=alpha_value, name=name)
 
-    else: # if context.in_graph_mode():
+        else:  # if context.in_graph_mode():
 
-        # For now, variant types must be created via zeros_like; as we need to
-        # pass the input variant object to the proper zeros callback.
+            # For now, variant types must be created via zeros_like; as we need to
+            # pass the input variant object to the proper zeros callback.
 
-        if (optimize and tensor.shape.is_fully_defined()):
-            # We can produce a zeros tensor independent of the value of 'tensor',
-            # since the shape is known statically.
-            ret = alphas(tensor.shape, alpha_value=alpha_value, name=name)
+            if (optimize and tensor.shape.is_fully_defined()):
+                # We can produce a zeros tensor independent of the value of 'tensor',
+                # since the shape is known statically.
+                ret = alphas(tensor.shape, alpha_value=alpha_value, name=name)
 
-        # elif dtype is not None and dtype != tensor.dtype and dtype != dtypes.variant:
-        else:
-            ret = alphas(
-                shape_internal(tensor, optimize=optimize),
-                alpha_value=alpha_value,
-                name=name
-            )
+            # elif dtype is not None and dtype != tensor.dtype and dtype != dtypes.variant:
+            else:
+                ret = alphas(shape_internal(tensor, optimize=optimize), alpha_value=alpha_value, name=name)
 
-        ret.set_shape(tensor.get_shape())
+            ret.set_shape(tensor.get_shape())
 
-    return ret
+        return ret

--- a/tensorlayer/array_ops.py
+++ b/tensorlayer/array_ops.py
@@ -53,7 +53,8 @@ def alphas(shape, alpha_value, name=None):
         except (TypeError, ValueError):
             output = fill(shape, constant(alpha_value, dtype=alpha_dtype), name=name)
 
-        assert output.dtype.base_dtype == alpha_dtype
+        if output.dtype.base_dtype != alpha_dtype:
+            raise AssertionError("Dtypes do not corresponds: %s and %s" % (output.dtype.base_dtype, alpha_dtype))
 
         return output
 

--- a/tensorlayer/array_ops.py
+++ b/tensorlayer/array_ops.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 """A file containing functions related to array manipulation."""
 
-import tensorflow as tf
-
 from tensorflow.python.eager import context
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
@@ -52,7 +50,7 @@ def alphas(shape, alpha_value, name=None):
         try:
             output = constant(alpha_value, shape=shape, dtype=alpha_dtype, name=name)
 
-        except (TypeError, ValueError) as e:
+        except (TypeError, ValueError):
             output = fill(shape, constant(alpha_value, dtype=alpha_dtype), name=name)
 
         assert output.dtype.base_dtype == alpha_dtype

--- a/tests/test_array_ops.py
+++ b/tests/test_array_ops.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import unittest
+
+import tensorflow as tf
+import tensorlayer as tl
+
+import numpy as np
+
+class Array_Op_Alphas_Test(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+
+        b1 = tl.alphas([4, 3, 2, 1], 0.5431)
+        b2 = tl.alphas([4, 3, 2], 5)
+        b3 = tl.alphas([1, 2, 3, 4], -5)
+        b4 = tl.alphas([2, 3, 4], True)
+
+        with tf.Session() as sess:
+            cls._b1, cls._b2, cls._b3, cls._b4 = sess.run([b1, b2, b3, b4])
+
+    @classmethod
+    def tearDownClass(cls):
+        tf.reset_default_graph()
+
+    def test_b1(self):
+        self.assertEqual(self._b1.shape, (4, 3, 2, 1))
+
+        b1 = np.array([
+            [[[0.5431],[0.5431],],[[0.5431],[0.5431],],[[0.5431],[0.5431],],],
+            [[[0.5431],[0.5431],],[[0.5431],[0.5431],],[[0.5431],[0.5431],],],
+            [[[0.5431],[0.5431],],[[0.5431],[0.5431],],[[0.5431],[0.5431],],],
+            [[[0.5431],[0.5431],],[[0.5431],[0.5431],],[[0.5431],[0.5431],],]
+        ])
+
+        np.array_equal(self._b1, b1)
+
+    def test_b2(self):
+        self.assertEqual(self._b2.shape, (4, 3, 2))
+
+        b2 = np.array([
+            [[5,5,],[5,5,],[5,5,],],
+            [[5,5,],[5,5,],[5,5,],],
+            [[5,5,],[5,5,],[5,5,],],
+            [[5,5,],[5,5,],[5,5,],]
+        ])
+
+        np.array_equal(self._b2, b2)
+
+    def test_b3(self):
+        self.assertEqual(self._b3.shape, (1, 2, 3, 4))
+
+
+        b3 = np.array([
+            [
+                [[-5, -5, -5, -5],[-5, -5, -5, -5],[-5, -5, -5, -5]],
+                [[-5, -5, -5, -5], [-5, -5, -5, -5], [-5, -5, -5, -5]],
+            ]
+        ])
+
+        np.array_equal(self._b3, b3)
+
+    def test_b4(self):
+        self.assertEqual(self._b4.shape, (2, 3, 4))
+
+        b4 = np.array([
+            [[True, True, True, True],[True, True, True, True],[True, True, True, True]],
+            [[True, True, True, True], [True, True, True, True], [True, True, True, True]],
+        ])
+
+        np.array_equal(self._b4, b4)
+
+
+class Array_Op_Alphas_Like_Test(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        a = tf.constant([
+            [
+                [4, 5, 6],
+                [1, 2, 3]
+            ],
+            [
+                [4, 5, 6],
+                [1, 2, 3]
+            ]
+        ])
+
+        b1 = tl.alphas_like(a, 0.5431)
+        b2 = tl.alphas_like(a, 5)
+        b3 = tl.alphas_like(a, -5)
+        b4 = tl.alphas_like(a, True)
+
+        with tf.Session() as sess:
+            cls._b1, cls._b2, cls._b3, cls._b4 = sess.run([b1, b2, b3, b4])
+
+    @classmethod
+    def tearDownClass(cls):
+        tf.reset_default_graph()
+
+    def test_b1(self):
+        self.assertEqual(self._b1.shape, (2, 2, 3))
+
+        b1 = np.array([[
+                [0.5431, 0.5431, 0.5431],
+                [0.5431, 0.5431, 0.5431]
+            ],
+            [
+                [0.5431, 0.5431, 0.5431],
+                [0.5431, 0.5431, 0.5431]
+            ]])
+
+        np.array_equal(self._b1, b1)
+
+    def test_b2(self):
+        self.assertEqual(self._b2.shape, (2, 2, 3))
+
+        b2 = np.array([[
+                [5, 5, 5],
+                [5, 5, 5]
+            ],
+            [
+                [5, 5, 5],
+                [5, 5, 5]
+            ]])
+
+        np.array_equal(self._b2, b2)
+
+    def test_b3(self):
+        self.assertEqual(self._b3.shape, (2, 2, 3))
+
+        b3 = np.array([[
+                [-5, -5, -5],
+                [-5, -5, -5]
+            ],
+            [
+                [-5, -5, -5],
+                [-5, -5, -5]
+            ]])
+
+        np.array_equal(self._b3, b3)
+
+    def test_b4(self):
+        self.assertEqual(self._b4.shape, (2, 2, 3))
+
+        b4 = np.array([[
+                [True, True, True],
+                [True, True, True]
+            ],
+            [
+                [True, True, True],
+                [True, True, True]
+            ]])
+
+        np.array_equal(self._b4, b4)
+
+
+if __name__ == '__main__':
+
+    # tf.logging.set_verbosity(tf.logging.INFO)
+    tf.logging.set_verbosity(tf.logging.DEBUG)
+
+    unittest.main()

--- a/tests/test_array_ops.py
+++ b/tests/test_array_ops.py
@@ -7,6 +7,7 @@ import tensorlayer as tl
 
 import numpy as np
 
+
 class Array_Op_Alphas_Test(unittest.TestCase):
 
     @classmethod
@@ -27,47 +28,152 @@ class Array_Op_Alphas_Test(unittest.TestCase):
     def test_b1(self):
         self.assertEqual(self._b1.shape, (4, 3, 2, 1))
 
-        b1 = np.array([
-            [[[0.5431],[0.5431],],[[0.5431],[0.5431],],[[0.5431],[0.5431],],],
-            [[[0.5431],[0.5431],],[[0.5431],[0.5431],],[[0.5431],[0.5431],],],
-            [[[0.5431],[0.5431],],[[0.5431],[0.5431],],[[0.5431],[0.5431],],],
-            [[[0.5431],[0.5431],],[[0.5431],[0.5431],],[[0.5431],[0.5431],],]
-        ])
+        b1 = np.array(
+            [
+                [
+                    [
+                        [0.5431],
+                        [0.5431],
+                    ],
+                    [
+                        [0.5431],
+                        [0.5431],
+                    ],
+                    [
+                        [0.5431],
+                        [0.5431],
+                    ],
+                ], [
+                    [
+                        [0.5431],
+                        [0.5431],
+                    ],
+                    [
+                        [0.5431],
+                        [0.5431],
+                    ],
+                    [
+                        [0.5431],
+                        [0.5431],
+                    ],
+                ], [
+                    [
+                        [0.5431],
+                        [0.5431],
+                    ],
+                    [
+                        [0.5431],
+                        [0.5431],
+                    ],
+                    [
+                        [0.5431],
+                        [0.5431],
+                    ],
+                ], [
+                    [
+                        [0.5431],
+                        [0.5431],
+                    ],
+                    [
+                        [0.5431],
+                        [0.5431],
+                    ],
+                    [
+                        [0.5431],
+                        [0.5431],
+                    ],
+                ]
+            ]
+        )
 
         np.array_equal(self._b1, b1)
 
     def test_b2(self):
         self.assertEqual(self._b2.shape, (4, 3, 2))
 
-        b2 = np.array([
-            [[5,5,],[5,5,],[5,5,],],
-            [[5,5,],[5,5,],[5,5,],],
-            [[5,5,],[5,5,],[5,5,],],
-            [[5,5,],[5,5,],[5,5,],]
-        ])
+        b2 = np.array(
+            [
+                [
+                    [
+                        5,
+                        5,
+                    ],
+                    [
+                        5,
+                        5,
+                    ],
+                    [
+                        5,
+                        5,
+                    ],
+                ], [
+                    [
+                        5,
+                        5,
+                    ],
+                    [
+                        5,
+                        5,
+                    ],
+                    [
+                        5,
+                        5,
+                    ],
+                ], [
+                    [
+                        5,
+                        5,
+                    ],
+                    [
+                        5,
+                        5,
+                    ],
+                    [
+                        5,
+                        5,
+                    ],
+                ], [
+                    [
+                        5,
+                        5,
+                    ],
+                    [
+                        5,
+                        5,
+                    ],
+                    [
+                        5,
+                        5,
+                    ],
+                ]
+            ]
+        )
 
         np.array_equal(self._b2, b2)
 
     def test_b3(self):
         self.assertEqual(self._b3.shape, (1, 2, 3, 4))
 
-
-        b3 = np.array([
+        b3 = np.array(
             [
-                [[-5, -5, -5, -5],[-5, -5, -5, -5],[-5, -5, -5, -5]],
-                [[-5, -5, -5, -5], [-5, -5, -5, -5], [-5, -5, -5, -5]],
+                [
+                    [[-5, -5, -5, -5], [-5, -5, -5, -5], [-5, -5, -5, -5]],
+                    [[-5, -5, -5, -5], [-5, -5, -5, -5], [-5, -5, -5, -5]],
+                ]
             ]
-        ])
+        )
 
         np.array_equal(self._b3, b3)
 
     def test_b4(self):
         self.assertEqual(self._b4.shape, (2, 3, 4))
 
-        b4 = np.array([
-            [[True, True, True, True],[True, True, True, True],[True, True, True, True]],
-            [[True, True, True, True], [True, True, True, True], [True, True, True, True]],
-        ])
+        b4 = np.array(
+            [
+                [[True, True, True, True], [True, True, True, True], [True, True, True, True]],
+                [[True, True, True, True], [True, True, True, True], [True, True, True, True]],
+            ]
+        )
 
         np.array_equal(self._b4, b4)
 
@@ -76,16 +182,7 @@ class Array_Op_Alphas_Like_Test(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        a = tf.constant([
-            [
-                [4, 5, 6],
-                [1, 2, 3]
-            ],
-            [
-                [4, 5, 6],
-                [1, 2, 3]
-            ]
-        ])
+        a = tf.constant([[[4, 5, 6], [1, 2, 3]], [[4, 5, 6], [1, 2, 3]]])
 
         b1 = tl.alphas_like(a, 0.5431)
         b2 = tl.alphas_like(a, 5)
@@ -102,56 +199,33 @@ class Array_Op_Alphas_Like_Test(unittest.TestCase):
     def test_b1(self):
         self.assertEqual(self._b1.shape, (2, 2, 3))
 
-        b1 = np.array([[
-                [0.5431, 0.5431, 0.5431],
-                [0.5431, 0.5431, 0.5431]
-            ],
+        b1 = np.array(
             [
-                [0.5431, 0.5431, 0.5431],
-                [0.5431, 0.5431, 0.5431]
-            ]])
+                [[0.5431, 0.5431, 0.5431], [0.5431, 0.5431, 0.5431]],
+                [[0.5431, 0.5431, 0.5431], [0.5431, 0.5431, 0.5431]]
+            ]
+        )
 
         np.array_equal(self._b1, b1)
 
     def test_b2(self):
         self.assertEqual(self._b2.shape, (2, 2, 3))
 
-        b2 = np.array([[
-                [5, 5, 5],
-                [5, 5, 5]
-            ],
-            [
-                [5, 5, 5],
-                [5, 5, 5]
-            ]])
+        b2 = np.array([[[5, 5, 5], [5, 5, 5]], [[5, 5, 5], [5, 5, 5]]])
 
         np.array_equal(self._b2, b2)
 
     def test_b3(self):
         self.assertEqual(self._b3.shape, (2, 2, 3))
 
-        b3 = np.array([[
-                [-5, -5, -5],
-                [-5, -5, -5]
-            ],
-            [
-                [-5, -5, -5],
-                [-5, -5, -5]
-            ]])
+        b3 = np.array([[[-5, -5, -5], [-5, -5, -5]], [[-5, -5, -5], [-5, -5, -5]]])
 
         np.array_equal(self._b3, b3)
 
     def test_b4(self):
         self.assertEqual(self._b4.shape, (2, 2, 3))
 
-        b4 = np.array([[
-                [True, True, True],
-                [True, True, True]
-            ],
-            [
-                [True, True, True],
-                [True, True, True]
-            ]])
+        b4 = np.array([[[True, True, True], [True, True, True]], [[True, True, True], [True, True, True]]])
 
         np.array_equal(self._b4, b4)
 


### PR DESCRIPTION
In a research project, I encountered the need to create tensors of the same shape than any other tensor with a custom value (not just 0 or 1), could be Boolean, Floats, Integers and so on.

For the record, it was something I originally developed for the TF repository (but they were not interested):  
- Issue: https://github.com/tensorflow/tensorflow/issues/16128
- PR: https://github.com/tensorflow/tensorflow/pull/16153

The functions prototypes are the following and have been implemented in [ tensorlayer/array_ops.py](https://github.com/tensorlayer/tensorlayer/blob/tl_array_ops/tensorlayer/array_ops.py): 
- **tl.alphas** (shape, alpha_value, name=None)
- **tl.alphas_like** (tensor, alpha_value, name=None, optimize=True)

The code is not created from scratch. It is **highly** inspired by the functions tf.ones, tf.zeros for tl.alphas and by tf.zeros_like, tf.ones_like for tl.alphas_like.

The code use the latest implementation and has been designed to work with *eager_mode*.
The number of modification is relatively small, thus I am relatively confident on the robustness of the new implementation (largely based on the existing one).

The idea is to reproduce and merge the functions while enabling to set any custom value in the tensor:

- **`tl.alphas` merges:**
  - tf.ones
  - tf.zeros
- **`tl.alphas_like` merges:**
  - tf.zeros_like
  - tf.ones_like

### How is the API Working ?

My new functions take a parameter _alpha_value_ and fill the tensor with this value. This allows me to run such a script:

```python
import tensorflow as tf
import tensorlayer as tl

a = tf.constant([
    [
        [4, 5, 6],
        [1, 2, 3]
    ],
    [
        [4, 5, 6],
        [1, 2, 3]
    ]
])

b1 = tl.alphas_like(a, 0.5431)
b2 = tl.alphas_like(a, 5)
b3 = tl.alphas_like(a, -5)
b4 = tl.alphas_like(a, True)

with tf.Session() as sess:
    _b1, _b2, _b3, _b4 = sess.run([b1, b2, b3, b4])
    
print("b1:", _b1)
print("b2:", _b2)
print("b3:", _b3)
print("b4:", _b4)

############### OUTPUTS ###############

>>> b1: [
  [
    [ 0.5431  0.5431  0.5431]
    [ 0.5431  0.5431  0.5431]
  ]
  [
    [ 0.5431  0.5431  0.5431]
    [ 0.5431  0.5431  0.5431]
  ]
]

>>> b2: [
  [
    [5 5 5]
    [5 5 5]
  ]
  [
    [5 5 5]
    [5 5 5]
  ]
]

>>> b3: [
  [
    [-5 -5 -5]
    [-5 -5 -5]
  ]
  [
    [-5 -5 -5]
    [-5 -5 -5]
  ]
]

>>> b4: [
  [
    [ True  True  True]
    [ True  True  True]
  ]
  [
    [ True  True  True]
    [ True  True  True]
  ]
]
```

### Performance Optimization

Of course, it could be to do the same thing using the following commands:

```python
b1 = tf.ones_like(a, dtype=tf.float32) * 0.5431
b2 = tf.ones_like(a, dtype=tf.int32) * 5
b4 = tf.ones_like(a, dtype=tf.bool)
```

Each run has been executed 5 times and execution time averaged:
- The method working with TF Code only (shown above) : [47.5s, 47.5s, 48.1s, 47.6s; 47.8s] => **Average Time: 47.7 secs**

- The method I implemented "alphas_like": [25.0s, 25.0s, 25.0s, 24.9s, 25.0s] => **Average Time: 25 secs**

**My method is almost twice as fast !**

### Code used to produce this numbers:

``` python
import tensorflow as tf
import time

a  = tf.ones(shape=(64,255,255,3))

method1 = tf.ones_like(a) * 2.55
method2 = tl.alphas_like(a, alpha_value=2.55)


for _ in range(5):
    TIC = time.time()
    for __ in range(100):

        with tf.Session() as sess:
            tmp = sess.run(method1)

    TOC = time.time()

    print("Execution with method 1 took: %sms" % str((TOC-TIC)*1000))

print("\n######################################\n")

for _ in range(5):
    TIC = time.time()
    for __ in range(100):

        with tf.Session() as sess:
            tmp = sess.run(method2)

    TOC = time.time()

    print("Execution with method 2 took: %sms" % str((TOC-TIC)*1000))
```

### Which gives me these results:

```
Execution with method 1 took: 47542.79899597168ms
Execution with method 1 took: 47539.61968421936ms
Execution with method 1 took: 48089.28418159485ms
Execution with method 1 took: 47630.205392837524ms
Execution with method 1 took: 47837.78142929077ms

######################################

Execution with method 2 took: 25034.541845321655ms
Execution with method 2 took: 25057.311058044434ms
Execution with method 2 took: 25051.66268348694ms
Execution with method 2 took: 24936.548471450806ms
Execution with method 2 took: 24955.832958221436ms
```
