### PR TITLE
ReadTheDocs Links Updated & Version added on index page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ To release a new version, please update the changelog as followed:
   - https://github.com/apps/stale/ added to clean stale issues (by @DEKHTIARJonathan in #573)
 - Layer:
   - ElementwiseLambdaLayer added to use custom function to connect multiple layer inputs (by @One-sixth in #579)
+- Documentation:
+  - Release semantic version added on index page (by @DEKHTIARJonathan in #633)
 
 ### Changed
 - Tensorflow CPU & GPU dependencies moved to separated requirement files in order to allow PyUP.io to parse them (by @DEKHTIARJonathan in #573)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ To release a new version, please update the changelog as followed:
 ### Changed
 - Tensorflow CPU & GPU dependencies moved to separated requirement files in order to allow PyUP.io to parse them (by @DEKHTIARJonathan in #573)
 - The document of LambdaLayer for linking it with ElementwiseLambdaLayer (by @zsdonghao in #587)
+- RTD links point to stable documentation instead of latest used for development (by @DEKHTIARJonathan in #633)
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
     </div>
 </div>
 -->
-<a href="http://tensorlayer.readthedocs.io">
+<a href="https://tensorlayer.readthedocs.io/">
 <div align="center">
 	<img src="img/tl_transparent_logo.png" width="50%" height="30%"/>
 </div>
@@ -17,7 +17,7 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/ca2a29ddcf7445588beff50bee5406d9)](https://app.codacy.com/app/tensorlayer/tensorlayer?utm_source=github.com&utm_medium=referral&utm_content=tensorlayer/tensorlayer&utm_campaign=badger)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/tensorlayer/Lobby#?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![Build Status](https://travis-ci.org/tensorlayer/tensorlayer.svg?branch=master)](https://travis-ci.org/tensorlayer/tensorlayer)
-[![Documentation Status](https://readthedocs.org/projects/tensorlayer/badge/?version=latest)](http://tensorlayer.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/tensorlayer/badge/?version=stable)](https://tensorlayer.readthedocs.io/)
 [![Docker Pulls](https://img.shields.io/docker/pulls/tensorlayer/tensorlayer.svg?maxAge=604800)](https://hub.docker.com/r/tensorlayer/tensorlayer/)
 [![PyUP Updates](https://pyup.io/repos/github/tensorlayer/tensorlayer/shield.svg)](https://pyup.io/repos/github/tensorlayer/tensorlayer/)
 [![Python 3](https://pyup.io/repos/github/tensorlayer/tensorlayer/python-3-shield.svg)](https://pyup.io/repos/github/tensorlayer/tensorlayer/)
@@ -35,23 +35,30 @@ TensorLayer is a deep learning and reinforcement learning library on top of [Ten
 <br/>
 
 - **You have found a bug**: Please open a [Github Issues](https://github.com/tensorlayer/tensorlayer/issues)
-- **Useful links:** [Documentation](http://tensorlayer.readthedocs.io), [Examples](http://tensorlayer.readthedocs.io/en/latest/user/example.html), [中文文档](https://tensorlayercn.readthedocs.io), [中文书](http://www.broadview.com.cn/book/5059)
+
+- **Useful links (EN):** 
+  - [Documentation](https://tensorlayer.readthedocs.io/)
+  - [Examples](https://tensorlayer.readthedocs.io/en/stable/user/example.html)
+  
+- **Useful links (CN):** 
+  - [中文文档](https://tensorlayercn.readthedocs.io)
+  - [中文书](http://www.broadview.com.cn/book/5059)
 
 # News
 * [10 Apr] Load and visualize MPII dataset in one line of code.
-* [05 Apr] Release [models APIs](http://tensorlayer.readthedocs.io/en/latest/modules/models.html#) for well-known pretained networks.
+* [05 Apr] Release [models APIs](https://tensorlayer.readthedocs.io/en/stable/modules/models.html) for well-known pretained networks.
 * [18 Mar] Release experimental APIs for binary networks.
 * [18 Jan] [《深度学习：一起玩转TensorLayer》](http://www.broadview.com.cn/book/5059) (Deep Learning using TensorLayer)
 * [17 Dec] Release experimental APIs for distributed training (by [TensorPort](https://tensorport.com)). See [tiny example](https://github.com/zsdonghao/tensorlayer/blob/master/example/tutorial_mnist_distributed.py).
-* [17 Nov] Release data augmentation APIs for object detection, see [tl.prepro](http://tensorlayer.readthedocs.io/en/latest/modules/prepro.html#object-detection).
-* [17 Nov] Support [Convolutional LSTM](https://arxiv.org/abs/1506.04214), see [ConvLSTMLayer](http://tensorlayer.readthedocs.io/en/latest/modules/layers.html#conv-lstm-layer).
-* [17 Nov] Support [Deformable Convolution](https://arxiv.org/abs/1703.06211), see [DeformableConv2dLayer](http://tensorlayer.readthedocs.io/en/latest/modules/layers.html#d-deformable-conv).
-* [17 Sep] New example [Chatbot in 200 lines of code](https://github.com/zsdonghao/seq2seq-chatbot) for [Seq2Seq](http://tensorlayer.readthedocs.io/en/latest/modules/layers.html#simple-seq2seq).
+* [17 Nov] Release data augmentation APIs for object detection, see [tl.prepro](https://tensorlayer.readthedocs.io/en/stable/modules/prepro.html#object-detection).
+* [17 Nov] Support [Convolutional LSTM](https://arxiv.org/abs/1506.04214), see [ConvLSTMLayer](https://tensorlayer.readthedocs.io/en/stable/modules/layers.html#conv-lstm-layer).
+* [17 Nov] Support [Deformable Convolution](https://arxiv.org/abs/1703.06211), see [DeformableConv2dLayer](https://tensorlayer.readthedocs.io/en/stable/modules/layers.html#d-deformable-conv).
+* [17 Sep] New example [Chatbot in 200 lines of code](https://github.com/zsdonghao/seq2seq-chatbot) for [Seq2Seq](https://tensorlayer.readthedocs.io/en/stable/modules/layers.html#simple-seq2seq).
 <!--
-* [17 Nov] Download [VOC dataset](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/) in one line, see [load\_voc_dataset](http://tensorlayer.readthedocs.io/en/latest/modules/files.html#voc-2007-2012).
-* [17 Sep] Release [ROI layer](http://tensorlayer.readthedocs.io/en/latest/modules/layers.html#roi-layer) for Object Detection.
-* [17 Jun] Release [SpatialTransformer2dAffineLayer](http://tensorlayer.readthedocs.io/en/latest/modules/layers.html#spatial-transformer) for [Spatial Transformer Networks](https://github.com/zsdonghao/Spatial-Transformer-Nets) see [example code](https://github.com/zsdonghao/Spatial-Transformer-Nets).
-* [17 Jun] Release [Sub-pixel Convolution 2D](http://tensorlayer.readthedocs.io/en/latest/modules/layers.html#super-resolution-layer) for Super-resolution see [SRGAN code](https://github.com/zsdonghao/SRGAN).
+* [17 Nov] Download [VOC dataset](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/) in one line, see [load\_voc_dataset](https://tensorlayer.readthedocs.io/en/stable/modules/files.html#voc-2007-2012).
+* [17 Sep] Release [ROI layer](https://tensorlayer.readthedocs.io/en/stable/modules/layers.html#roi-layer) for Object Detection.
+* [17 Jun] Release [SpatialTransformer2dAffineLayer](https://tensorlayer.readthedocs.io/en/stable/modules/layers.html#spatial-transformer) for [Spatial Transformer Networks](https://github.com/zsdonghao/Spatial-Transformer-Nets) see [example code](https://github.com/zsdonghao/Spatial-Transformer-Nets).
+* [17 Jun] Release [Sub-pixel Convolution 2D](https://tensorlayer.readthedocs.io/en/stable/modules/layers.html#super-resolution-layer) for Super-resolution see [SRGAN code](https://github.com/zsdonghao/SRGAN).
 * [17 May] You can now use TensorLayer with [TFSlim](https://github.com/tensorlayer/tensorlayer/blob/master/example/tutorial_inceptionV3_tfslim.py) and [Keras](https://github.com/tensorlayer/tensorlayer/blob/master/example/tutorial_keras.py) together!
 -->
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,6 +7,8 @@ Welcome to TensorLayer
   :align: center
   :target: https://github.com/tensorlayer/tensorlayer
 
+**Documentation Version:** |release|
+  
 **Good News:** We won the **Best Open Source Software Award** `@ACM Multimedia (MM) 2017 <http://www.acmmm.org/2017/mm-2017-awardees/>`_.
 
 `TensorLayer`_ is a Deep Learning (DL) and Reinforcement Learning (RL) library extended from `Google TensorFlow <https://www.tensorflow.org>`_.  It provides popular DL and RL modules that can be easily customized and assembled for tackling real-world machine learning problems.


### PR DESCRIPTION
RTD links updated to point to `stable` build instead of `latest` (dev) build.
RTD now pointing to https version.

I also have added the release version on index page for clarity (it doesn't need to be updated manually)

**Screenshot:**
![image](https://user-images.githubusercontent.com/10923599/40169661-c9096a0e-59c6-11e8-9be6-7beccbfee961.png)
