### PR TITLE
TF Build Matrix added for Travis

### DIFF
--- a/.github/changelog.yml
+++ b/.github/changelog.yml
@@ -1,6 +1,39 @@
 filename: CHANGELOG.md
 include:
-  - /^tensorlayer\//
-  - /^tests\//
+  # Folders
+  - /^.github\//
   - /^docs\//
   - /^example\//
+  - /^tensorlayer\//
+  - /^tests\//
+
+  # Python Package Files
+  - setup.py
+  - setup.cfg
+  - pytest.ini
+
+  # Dependency Files
+  - requirements.txt
+  - requirements_db.txt
+  - requirements_dev.txt
+  - requirements_tf_cpu.txt
+  - requirements_tf_gpu.txt
+
+  # Configuration Files
+  - .travis.yml
+  - .readthedocs.yml
+  - .pyup.yml
+
+  # Docker Files
+  - Dockerfile
+  - Dockerfile.gpu
+  - .dockerignore
+
+  # Text Files
+  - README.md
+  - LICENSE.rst
+  - CHANGELOG.md
+  - CONTRIBUTING.md
+
+  # Github Files
+  - .gitignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 # https://docs.travis-ci.com/user/languages/python/
 language: python
 
+branches:
+  only:
+    - master
+
 python:
   - "2.7"
   - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,26 +5,26 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
+  
+matrix:
+  include:
+    - language: python
+      env:   
+      # Backward Compatibility in insured for release less than 1 year old.
+      # https://pypi.org/project/tensorflow/#history
+      
+      - _TF_VERSION=1.8.0 # Remove on Apr 28, 2019
+      - _TF_VERSION=1.7.1 # Remove on May 08, 2019
+      - _TF_VERSION=1.7.0 # Remove on Mar 29, 2019
+      - _TF_VERSION=1.6.0 # Remove on Mar 01, 2019
+      - _TF_VERSION=1.5.1 # Remove on Mar 20, 2019
+      - _TF_VERSION=1.5.0 # Remove on Jan 26, 2019
+      - _TF_VERSION=1.4.1 # Remove on Dec 08, 2018
+      - _TF_VERSION=1.4.0 # Remove on Nov 01, 2018
+      - _TF_VERSION=1.3.0 # Remove on Aug 16, 2018
+      - _TF_VERSION=1.2.1 # Remove on Jun 30, 2018
 
 env:
-  # %%%%%%%%%%%%%%%%%%%%%%%%% Build Matrix %%%%%%%%%%%%%%%%%%%%%%%%%
-  
-  # Backward Compatibility in insured for release less than 1 year old.
-  # https://pypi.org/project/tensorflow/#history
-  
-  - !!python/unicode '_TF_VERSION=1.8.0' # Remove on Apr 28, 2019
-  - !!python/unicode '_TF_VERSION=1.7.1' # Remove on May 08, 2019
-  - !!python/unicode '_TF_VERSION=1.7.0' # Remove on Mar 29, 2019
-  - !!python/unicode '_TF_VERSION=1.6.0' # Remove on Mar 01, 2019
-  - !!python/unicode '_TF_VERSION=1.5.1' # Remove on Mar 20, 2019
-  - !!python/unicode '_TF_VERSION=1.5.0' # Remove on Jan 26, 2019
-  - !!python/unicode '_TF_VERSION=1.4.1' # Remove on Dec 08, 2018
-  - !!python/unicode '_TF_VERSION=1.4.0' # Remove on Nov 01, 2018
-  - !!python/unicode '_TF_VERSION=1.3.0' # Remove on Aug 16, 2018
-  - !!python/unicode '_TF_VERSION=1.2.1' # Remove on Jun 30, 2018
-  - !!python/unicode '_TF_VERSION=1.2.0' # Remove on Jun 15, 2018
-  
-  # %%%%%%%%%%%%%%%%%%%%%%%%% Global Vars %%%%%%%%%%%%%%%%%%%%%%%%%%
   global:
 
   - PYPI_USER='jonathandekhtiar'

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,12 +57,13 @@ deploy:
 
 # Documentation: https://docs.travis-ci.com/user/deployment/pypi/
 - provider: pypi
-  user: "$PYPI_USER"
-  password: "$PYPI_PASSWORD"
+  user: '$PYPI_USER'
+  password: '$PYPI_PASSWORD'
   skip_cleanup: true
   on:
     tags: true
     python: '3.6'
+    condition: '$_TF_VERSION = 1.8.0'
 
 # Documentation: https://docs.travis-ci.com/user/deployment/releases/
 - provider: releases
@@ -71,7 +72,8 @@ deploy:
     - tensorlayer.egg-info/PKG-INFO
   file_glob: true
   skip_cleanup: true
-  api_key: "$GITHUB_PERSONAL_TOKEN"
+  api_key: '$GITHUB_PERSONAL_TOKEN'
   on:
     tags: true
     python: '3.6'
+    condition: '$_TF_VERSION = 1.8.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,13 @@ env:
     - _TF_VERSION=1.7.1 # Remove on May 08, 2019
     - _TF_VERSION=1.7.0 # Remove on Mar 29, 2019
     - _TF_VERSION=1.6.0 # Remove on Mar 01, 2019
-    - _TF_VERSION=1.5.1 # Remove on Mar 20, 2019
-    - _TF_VERSION=1.5.0 # Remove on Jan 26, 2019
-    - _TF_VERSION=1.4.1 # Remove on Dec 08, 2018
-    - _TF_VERSION=1.4.0 # Remove on Nov 01, 2018
-    - _TF_VERSION=1.3.0 # Remove on Aug 16, 2018
-    - _TF_VERSION=1.2.1 # Remove on Jun 30, 2018
-    
+    # - _TF_VERSION=1.5.1 # Remove on Mar 20, 2019
+    # - _TF_VERSION=1.5.0 # Remove on Jan 26, 2019
+    # - _TF_VERSION=1.4.1 # Remove on Dec 08, 2018
+    # - _TF_VERSION=1.4.0 # Remove on Nov 01, 2018
+    # - _TF_VERSION=1.3.0 # Remove on Aug 16, 2018
+    # - _TF_VERSION=1.2.1 # Remove on Jun 30, 2018
+
   global:
 
   - PYPI_USER='jonathandekhtiar'
@@ -43,7 +43,7 @@ install:
 script:
   # units test
   # https://docs.pytest.org/en/latest/
-  - pytest  
+  - pytest
 
 
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,25 +5,23 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
-  
-matrix:
+
+env:
 
   # Backward Compatibility in insured for release less than 1 year old.
   # https://pypi.org/project/tensorflow/#history
-      
-  include:
-    - env: _TF_VERSION=1.8.0 # Remove on Apr 28, 2019
-    - env: _TF_VERSION=1.7.1 # Remove on May 08, 2019
-    - env: _TF_VERSION=1.7.0 # Remove on Mar 29, 2019
-    - env: _TF_VERSION=1.6.0 # Remove on Mar 01, 2019
-    - env: _TF_VERSION=1.5.1 # Remove on Mar 20, 2019
-    - env: _TF_VERSION=1.5.0 # Remove on Jan 26, 2019
-    - env: _TF_VERSION=1.4.1 # Remove on Dec 08, 2018
-    - env: _TF_VERSION=1.4.0 # Remove on Nov 01, 2018
-    - env: _TF_VERSION=1.3.0 # Remove on Aug 16, 2018
-    - env: _TF_VERSION=1.2.1 # Remove on Jun 30, 2018
-
-env:
+  matrix:
+    - _TF_VERSION=1.8.0 # Remove on Apr 28, 2019
+    - _TF_VERSION=1.7.1 # Remove on May 08, 2019
+    - _TF_VERSION=1.7.0 # Remove on Mar 29, 2019
+    - _TF_VERSION=1.6.0 # Remove on Mar 01, 2019
+    - _TF_VERSION=1.5.1 # Remove on Mar 20, 2019
+    - _TF_VERSION=1.5.0 # Remove on Jan 26, 2019
+    - _TF_VERSION=1.4.1 # Remove on Dec 08, 2018
+    - _TF_VERSION=1.4.0 # Remove on Nov 01, 2018
+    - _TF_VERSION=1.3.0 # Remove on Aug 16, 2018
+    - _TF_VERSION=1.2.1 # Remove on Jun 30, 2018
+    
   global:
 
   - PYPI_USER='jonathandekhtiar'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,24 @@ python:
   - "3.6"
 
 env:
+  # %%%%%%%%%%%%%%%%%%%%%%%%% Build Matrix %%%%%%%%%%%%%%%%%%%%%%%%%
+  
+  # Backward Compatibility in insured for release less than 1 year old.
+  # https://pypi.org/project/tensorflow/#history
+  
+  - !!python/unicode '_TF_VERSION=1.8.0' # Remove on Apr 28, 2019
+  - !!python/unicode '_TF_VERSION=1.7.1' # Remove on May 08, 2019
+  - !!python/unicode '_TF_VERSION=1.7.0' # Remove on Mar 29, 2019
+  - !!python/unicode '_TF_VERSION=1.6.0' # Remove on Mar 01, 2019
+  - !!python/unicode '_TF_VERSION=1.5.1' # Remove on Mar 20, 2019
+  - !!python/unicode '_TF_VERSION=1.5.0' # Remove on Jan 26, 2019
+  - !!python/unicode '_TF_VERSION=1.4.1' # Remove on Dec 08, 2018
+  - !!python/unicode '_TF_VERSION=1.4.0' # Remove on Nov 01, 2018
+  - !!python/unicode '_TF_VERSION=1.3.0' # Remove on Aug 16, 2018
+  - !!python/unicode '_TF_VERSION=1.2.1' # Remove on Jun 30, 2018
+  - !!python/unicode '_TF_VERSION=1.2.0' # Remove on Jun 15, 2018
+  
+  # %%%%%%%%%%%%%%%%%%%%%%%%% Global Vars %%%%%%%%%%%%%%%%%%%%%%%%%%
   global:
 
   - PYPI_USER='jonathandekhtiar'
@@ -22,7 +40,8 @@ env:
   - secure: "kMxg4WfTwhnYMD7WjYk71vgw7XlShPpANauKzfTL6oawDrpQRkBUai4uQwiL3kXVBuVv9rKKKZxxnyAm05iB5wGasPDhlFA1DPF0IbyU3pwQKlw2Xo5qtHdgxBnbms6JJ9z5b+hHCVg+LXYYeUw5qG01Osg5Ue6j1g2juQQHCod00FNuo3fe8ah/Y10Rem6CigH8ofosCrTvN2w1GaetJwVehRYf8JkPC6vQ+Yk8IIjHn2CaVJALbhuchVblxwH0NXXRen915BVBwWRQtsrvEVMXKu7A8sMHmvPz1u3rhXQfjpF2KeVOfy1ZnyiHcLE2HgAPuAGh4kxZAAA8ovmcaCbv8m64bm72BrQApSbt6OEtR9L1UeUwdEgi54FH1XFOHQ9dA6CpiGCyk3wAJZqO0/PkNYVLfb4gPLvnvBRwYBaPgUPvVNhidFu/oODENZmcf8g9ChtuC1GT70EYlVwhgDGqUY7/USZCEvIPe81UToqtIKgcgA+Is51XindumJVMiqTsjgdqeC/wZcw+y37TAjIvvXbtYxeqIKv9zh1JuZppqUhnf+OhI+HHFaY4iu7lQTs3C0WmoLskZAp9srwRtifnVFFkdYzngmPaSjWyko2qiS0cTdFJQB/ljqmnJdksacbv5OOa0Q4qZef/hW774nVx105FlkAIk70D2b5l2pA="
 
 install:
-  - pip install -e .[tf_cpu,db,dev,test,doc]
+  - pip install tensorflow==$_TF_VERSION
+  - pip install -e .[db,dev,test,doc]
 
 script:
   # units test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,22 +7,21 @@ python:
   - "3.6"
   
 matrix:
-  include:
-    - language: python
-      env:   
-      # Backward Compatibility in insured for release less than 1 year old.
-      # https://pypi.org/project/tensorflow/#history
+
+  # Backward Compatibility in insured for release less than 1 year old.
+  # https://pypi.org/project/tensorflow/#history
       
-      - _TF_VERSION=1.8.0 # Remove on Apr 28, 2019
-      - _TF_VERSION=1.7.1 # Remove on May 08, 2019
-      - _TF_VERSION=1.7.0 # Remove on Mar 29, 2019
-      - _TF_VERSION=1.6.0 # Remove on Mar 01, 2019
-      - _TF_VERSION=1.5.1 # Remove on Mar 20, 2019
-      - _TF_VERSION=1.5.0 # Remove on Jan 26, 2019
-      - _TF_VERSION=1.4.1 # Remove on Dec 08, 2018
-      - _TF_VERSION=1.4.0 # Remove on Nov 01, 2018
-      - _TF_VERSION=1.3.0 # Remove on Aug 16, 2018
-      - _TF_VERSION=1.2.1 # Remove on Jun 30, 2018
+  include:
+    - env: _TF_VERSION=1.8.0 # Remove on Apr 28, 2019
+    - env: _TF_VERSION=1.7.1 # Remove on May 08, 2019
+    - env: _TF_VERSION=1.7.0 # Remove on Mar 29, 2019
+    - env: _TF_VERSION=1.6.0 # Remove on Mar 01, 2019
+    - env: _TF_VERSION=1.5.1 # Remove on Mar 20, 2019
+    - env: _TF_VERSION=1.5.0 # Remove on Jan 26, 2019
+    - env: _TF_VERSION=1.4.1 # Remove on Dec 08, 2018
+    - env: _TF_VERSION=1.4.0 # Remove on Nov 01, 2018
+    - env: _TF_VERSION=1.3.0 # Remove on Aug 16, 2018
+    - env: _TF_VERSION=1.2.1 # Remove on Jun 30, 2018
 
 env:
   global:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,8 +79,9 @@ To release a new version, please update the changelog as followed:
   - `Array_Op_Alphas_Test` and `Array_Op_Alphas_Like_Test` added to test `tensorlayer/array_ops.py` file (by @DEKHTIARJonathan in #580)
   - `test_optimizer_amsgrad.py` added to test `AMSGrad` optimizer (by @DEKHTIARJonathan in #636)
 - CI Tool:
-  - https://github.com/apps/stale/ added to clean stale issues (by @DEKHTIARJonathan in #573)
-  - Changelog Probot Configuration added (by @DEKHTIARJonathan in #637)
+  - [Stale Probot](https://github.com/probot/stale) added to clean stale issues (by @DEKHTIARJonathan in #573)
+  - [Changelog Probot](https://github.com/mikz/probot-changelog) Configuration added (by @DEKHTIARJonathan in #637)
+  - Travis Builds now handling a matrix of TF Version from TF==1.6.0 to TF==1.8.0 (by @DEKHTIARJonathan in #644)
 - Layer:
   - ElementwiseLambdaLayer added to use custom function to connect multiple layer inputs (by @One-sixth in #579)
 - Documentation:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ To release a new version, please update the changelog as followed:
 - Tensorflow CPU & GPU dependencies moved to separated requirement files in order to allow PyUP.io to parse them (by @DEKHTIARJonathan in #573)
 - The document of LambdaLayer for linking it with ElementwiseLambdaLayer (by @zsdonghao in #587)
 - RTD links point to stable documentation instead of latest used for development (by @DEKHTIARJonathan in #633)
+- TF Version older than 1.6.0 are officially unsupported and raises an exception (by @DEKHTIARJonathan in #644)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ To release a new version, please update the changelog as followed:
 - The document of LambdaLayer for linking it with ElementwiseLambdaLayer (by @zsdonghao in #587)
 - RTD links point to stable documentation instead of latest used for development (by @DEKHTIARJonathan in #633)
 - TF Version older than 1.6.0 are officially unsupported and raises an exception (by @DEKHTIARJonathan in #644)
+- Readme Badges Updated with Support Python and Tensorflow Versions (by @DEKHTIARJonathan in #644)
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -13,14 +13,17 @@
 </div>
 </a>
 
-[![PyPI version](https://badge.fury.io/py/tensorlayer.svg)](https://badge.fury.io/py/tensorlayer)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/ca2a29ddcf7445588beff50bee5406d9)](https://app.codacy.com/app/tensorlayer/tensorlayer?utm_source=github.com&utm_medium=referral&utm_content=tensorlayer/tensorlayer&utm_campaign=badger)
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/tensorlayer/Lobby#?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![Build Status](https://travis-ci.org/tensorlayer/tensorlayer.svg?branch=master)](https://travis-ci.org/tensorlayer/tensorlayer)
-[![Documentation Status](https://readthedocs.org/projects/tensorlayer/badge/?version=stable)](https://tensorlayer.readthedocs.io/)
+[![PyPI version](https://badge.fury.io/py/tensorlayer.svg)](https://pypi.org/project/tensorlayer/)
+[![Github commits (since latest release)](https://img.shields.io/github/commits-since/tensorlayer/tensorlayer/latest.svg)](https://github.com/tensorlayer/tensorlayer/compare/1.8.5...master)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/tensorlayer.svg)](https://pypi.org/project/tensorlayer/)
+[![Supported TF Version](https://img.shields.io/badge/tensorflow-1.6.0+-blue.svg)](https://github.com/tensorflow/tensorflow/releases)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/ca2a29ddcf7445588beff50bee5406d9)](https://app.codacy.com/app/tensorlayer/tensorlayer)
 [![Docker Pulls](https://img.shields.io/docker/pulls/tensorlayer/tensorlayer.svg?maxAge=604800)](https://hub.docker.com/r/tensorlayer/tensorlayer/)
+
+[![Documentation Status](https://readthedocs.org/projects/tensorlayer/badge/?version=stable)](https://tensorlayer.readthedocs.io/)
 [![PyUP Updates](https://pyup.io/repos/github/tensorlayer/tensorlayer/shield.svg)](https://pyup.io/repos/github/tensorlayer/tensorlayer/)
-[![Python 3](https://pyup.io/repos/github/tensorlayer/tensorlayer/python-3-shield.svg)](https://pyup.io/repos/github/tensorlayer/tensorlayer/)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/tensorlayer/Lobby)
 
 TensorLayer is a deep learning and reinforcement learning library on top of [TensorFlow](https://www.tensorflow.org). It provides rich neural layers and utility functions to help researchers and engineers build real-world AI applications. TensorLayer is awarded the 2017 Best Open Source Software by the prestigious [ACM Multimedia Society](http://www.acmmm.org/2017/mm-2017-awardees/).
 

--- a/tensorlayer/__init__.py
+++ b/tensorlayer/__init__.py
@@ -6,6 +6,14 @@ from __future__ import absolute_import
 try:
     import tensorflow
 
+    if tensorflow.__version__ < "1.6.0":
+        raise RuntimeError(
+            "TensorLayer does not support Tensorflow version older than 1.6.0.\n"
+            "Please update Tensorflow with:\n"
+            " - `pip install --upgrade tensorflow`\n"
+            " - `pip install --upgrade tensorflow-gpu`"
+        )
+
     from . import activation
     from . import array_ops
     from . import cost


### PR DESCRIPTION
This PR aims to insure that TL is compatible with **not only** the latest version of TF.
I have taken a history of 1 year into account.

To insure that no-one is using TL with a TF version lower than 1.6.0 I have added a small test on import, it raises the following error if the TF version is inferior to 1.6.0.

```python
>>> import tensorflow as tf
>>> import tensorlayer as tl

Traceback (most recent call last):
ImportError: __init__.py : Could not import TensorLayer.
Error: TensorLayer does not support Tensorflow version older than 1.6.0.
Please update Tensorflow with:
 - `pip install --upgrade tensorflow`
 - `pip install --upgrade tensorflow-gpu`
```

Highlighted Failures:
 - Tensorflow == 1.5.1 : **Failure** => [Build Job](https://travis-ci.org/tensorlayer/tensorlayer/jobs/382058961)
 - Tensorflow == 1.5.0 : **Failure** => [Build Job](https://travis-ci.org/tensorlayer/tensorlayer/jobs/382058962)
 - Tensorflow == 1.4.1 : **Failure** => [Build Job](https://travis-ci.org/tensorlayer/tensorlayer/jobs/382058963)
 - Tensorflow == 1.4.0 : **Failure** => [Build Job](https://travis-ci.org/tensorlayer/tensorlayer/jobs/382058964)
 - Tensorflow == 1.3.0 : **Failure** => [Build Job](https://travis-ci.org/tensorlayer/tensorlayer/jobs/382058965)
 - Tensorflow == 1.2.1 : **Failure** => [Build Job](https://travis-ci.org/tensorlayer/tensorlayer/jobs/382058966)

Travis is now building the following: [Travis Build](https://travis-ci.org/tensorlayer/tensorlayer/builds/382058956)

![image](https://user-images.githubusercontent.com/10923599/40355890-dc304a90-5db7-11e8-9ae4-2b912a789760.png)

