### PR TITLE
ReLU6 rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ To release a new version, please update the changelog as followed:
 - API:
   - `tl.alphas` and `tl.alphas_like` added following the tf.ones/zeros and tf.zeros_like/ones_like (by @DEKHTIARJonathan in #580)
   - `tl.lazy_imports.LazyImport` to import heavy libraries only when necessary (by @DEKHTIARJonathan in #667)
+  - `tl.act.leaky_relu6` and `tl.layers.PRelu6Layer` have been (by @DEKHTIARJonathan in #686)
 - CI Tool:
   - [Stale Probot](https://github.com/probot/stale) added to clean stale issues (by @DEKHTIARJonathan in #573)
   - [Changelog Probot](https://github.com/mikz/probot-changelog) Configuration added (by @DEKHTIARJonathan in #637)
@@ -135,6 +136,7 @@ To release a new version, please update the changelog as followed:
 
 ### Deprecated
 - `tl.layers.TimeDistributedLayer` argurment `args` is deprecated in favor of `layer_args` (by @DEKHTIARJonathan in #667)
+- `tl.act.leaky_relu` have been deprecated in favor of `tf.nn.leaky_relu` (by @DEKHTIARJonathan in #686)
 
 ### Removed
 - `assert()` calls remove and replaced by `raise AssertionError()` (by @DEKHTIARJonathan in #667)
@@ -156,6 +158,7 @@ To release a new version, please update the changelog as followed:
 - Tutorial:
   - `tutorial_word2vec_basic.py` saving issue #476 fixed (by @DEKHTIARJonathan in #635)
   - All tutorials tested and errors have been fixed (by @DEKHTIARJonathan in #635)
+
 ### Security
 
 ### Dependencies Update
@@ -173,6 +176,7 @@ To release a new version, please update the changelog as followed:
 - API:
   - `tl.alphas` and `tl.alphas_like` added following the tf.ones/zeros and tf.zeros_like/ones_like (by @DEKHTIARJonathan in #580)
   - `tl.lazy_imports.LazyImport` to import heavy libraries only when necessary (by @DEKHTIARJonathan in #667)
+  - `tl.act.leaky_relu6` and `tl.layers.PRelu6Layer` have been (by @DEKHTIARJonathan in #686)
 - CI Tool:
   - [Stale Probot](https://github.com/probot/stale) added to clean stale issues (by @DEKHTIARJonathan in #573)
   - [Changelog Probot](https://github.com/mikz/probot-changelog) Configuration added (by @DEKHTIARJonathan in #637)
@@ -196,6 +200,7 @@ To release a new version, please update the changelog as followed:
 - Layer:
   - ElementwiseLambdaLayer added to use custom function to connect multiple layer inputs (by @One-sixth in #579)
   - AtrousDeConv2dLayer added (by @2wins in #662)
+  - Fix bugs of using `tf.layers` in CNN (by @zsdonghao in #686)
 - Optimizer:
   - AMSGrad Optimizer added based on `On the Convergence of Adam and Beyond (ICLR 2018)` (by @DEKHTIARJonathan in #636)
 - Setup:
@@ -235,6 +240,7 @@ To release a new version, please update the changelog as followed:
 
 ### Deprecated
 - `tl.layers.TimeDistributedLayer` argurment `args` is deprecated in favor of `layer_args` (by @DEKHTIARJonathan in #667)
+- `tl.act.leaky_relu` have been deprecated in favor of `tf.nn.leaky_relu` (by @DEKHTIARJonathan in #686)
 
 ### Removed
 - `assert()` calls remove and replaced by `raise AssertionError()` (by @DEKHTIARJonathan in #667)
@@ -256,6 +262,7 @@ To release a new version, please update the changelog as followed:
 - Tutorial:
   - `tutorial_word2vec_basic.py` saving issue #476 fixed (by @DEKHTIARJonathan in #635)
   - All tutorials tested and errors have been fixed (by @DEKHTIARJonathan in #635)
+
 ### Security
 
 ### Dependencies Update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ To release a new version, please update the changelog as followed:
   - `tl.alphas` and `tl.alphas_like` added following the tf.ones/zeros and tf.zeros_like/ones_like (by @DEKHTIARJonathan in #580)
   - `tl.lazy_imports.LazyImport` to import heavy libraries only when necessary (by @DEKHTIARJonathan in #667)
   - `tl.act.leaky_relu6` and `tl.layers.PRelu6Layer` have been (by @DEKHTIARJonathan in #686)
+  - `tl.act.leaky_twice_relu6` and `tl.layers.PTRelu6Layer` have been (by @DEKHTIARJonathan in #686)
 - CI Tool:
   - [Stale Probot](https://github.com/probot/stale) added to clean stale issues (by @DEKHTIARJonathan in #573)
   - [Changelog Probot](https://github.com/mikz/probot-changelog) Configuration added (by @DEKHTIARJonathan in #637)
@@ -108,6 +109,7 @@ To release a new version, please update the changelog as followed:
   - `test_optimizer_amsgrad.py` added to test `AMSGrad` optimizer (by @DEKHTIARJonathan in #636)
   - `test_logging.py` added to insure robustness of the logging API (by @DEKHTIARJonathan in #645)
   - `test_decorators.py` added (by @DEKHTIARJonathan in #660)
+  - `test_activations.py` added (by @DEKHTIARJonathan in #686)
 - Tutorials:
   - `tutorial_tfslim` has been introduced to show how to use `SlimNetsLayer` (by @2wins in #560).
 

--- a/docs/modules/activation.rst
+++ b/docs/modules/activation.rst
@@ -28,6 +28,7 @@ For more complex activation, TensorFlow API will be required.
 
    ramp
    leaky_relu
+   leaky_relu6
    swish
    sign
    hard_tanh
@@ -37,9 +38,13 @@ Ramp
 ------
 .. autofunction:: ramp
 
-Leaky Relu
+Leaky ReLU
 ------------
 .. autofunction:: leaky_relu
+
+Leaky ReLU6
+------------
+.. autofunction:: leaky_relu6
 
 Swish
 ------------

--- a/docs/modules/activation.rst
+++ b/docs/modules/activation.rst
@@ -26,9 +26,10 @@ For more complex activation, TensorFlow API will be required.
 
 .. autosummary::
 
-   ramp
    leaky_relu
    leaky_relu6
+   leaky_twice_relu6
+   ramp
    swish
    sign
    hard_tanh
@@ -45,6 +46,10 @@ Leaky ReLU
 Leaky ReLU6
 ------------
 .. autofunction:: leaky_relu6
+
+Twice Leaky ReLU6
+-----------------
+.. autofunction:: leaky_twice_relu6
 
 Swish
 ------------

--- a/docs/modules/layers.rst
+++ b/docs/modules/layers.rst
@@ -886,13 +886,15 @@ Scale
 Parametric activation layer
 ---------------------------
 
+PReLU Layer
+^^^^^^^^^^^
 .. autoclass:: PReluLayer
 
 
-Parametric activation layer
----------------------------
-
+PReLU6 Layer
+^^^^^^^^^^^^
 .. autoclass:: PRelu6Layer
+
 
 Flow control layer
 ----------------------

--- a/docs/modules/layers.rst
+++ b/docs/modules/layers.rst
@@ -345,6 +345,8 @@ Layer list
    ScaleLayer
 
    PReluLayer
+   PRelu6Layer
+   PTRelu6Layer
 
    MultiplexerLayer
 
@@ -894,6 +896,11 @@ PReLU Layer
 PReLU6 Layer
 ^^^^^^^^^^^^
 .. autoclass:: PRelu6Layer
+
+
+PTReLU6 Layer
+^^^^^^^^^^^^^
+.. autoclass:: PTRelu6Layer
 
 
 Flow control layer

--- a/docs/modules/layers.rst
+++ b/docs/modules/layers.rst
@@ -888,6 +888,12 @@ Parametric activation layer
 
 .. autoclass:: PReluLayer
 
+
+Parametric activation layer
+---------------------------
+
+.. autoclass:: PRelu6Layer
+
 Flow control layer
 ----------------------
 

--- a/tensorlayer/activation.py
+++ b/tensorlayer/activation.py
@@ -6,12 +6,18 @@ import tensorflow as tf
 from tensorflow.python.util.deprecation import deprecated
 
 __all__ = [
-    'ramp',
     'leaky_relu',
+    'leaky_relu6',
+    'leaky_twice_relu6',
+    'lrelu',
+    'lrelu6',
+    'ltrelu6',
+    'ramp',
     'swish',
     'sign',
+    'htanh',
+    'hard_tanh',
     'pixel_wise_softmax',
-    'lrelu',
 ]
 
 
@@ -40,9 +46,14 @@ def ramp(x, v_min=0, v_max=1, name=None):
 
 @deprecated("2018-09-30", "This API is deprecated. Please use as `tf.nn.leaky_relu`.")
 def leaky_relu(x, alpha=0.2, name="leaky_relu"):
-    """LeakyReLU, shortcut is ``lrelu``.
+    """leaky_relu can be used through its shortcut: :func:`tl.act.lrelu`.
 
-    Modified version of ReLU, introducing a nonzero gradient for negative input.
+    This function is a modified version of ReLU, introducing a nonzero gradient for negative input. Introduced by the paper:
+    `Rectifier Nonlinearities Improve Neural Network Acoustic Models [A. L. Maas et al., 2013] <https://ai.stanford.edu/~amaas/papers/relu_hybrid_icml2013_final.pdf>`__
+
+    The function return the following results:
+      - When x < 0: ``f(x) = alpha_low * x``.
+      - When x >= 0: ``f(x) = x``.
 
     Parameters
     ----------
@@ -65,9 +76,12 @@ def leaky_relu(x, alpha=0.2, name="leaky_relu"):
 
     References
     ----------
-    - `Rectifier Nonlinearities Improve Neural Network Acoustic Models, Maas et al. (2013) <http://web.stanford.edu/~awni/papers/relu_hybrid_icml2013_final.pdf>`__
+    - `Rectifier Nonlinearities Improve Neural Network Acoustic Models [A. L. Maas et al., 2013] <https://ai.stanford.edu/~amaas/papers/relu_hybrid_icml2013_final.pdf>`__
 
     """
+
+    if not (0 < alpha <= 1):
+        raise ValueError("`alpha` value must be in [0, 1]`")
 
     with tf.name_scope(name, "leaky_relu") as name_scope:
         x = tf.convert_to_tensor(x, name="features")
@@ -75,11 +89,18 @@ def leaky_relu(x, alpha=0.2, name="leaky_relu"):
 
 
 def leaky_relu6(x, alpha=0.2, name="leaky_relu6"):
-    """LeakyReLU6, shortcut is ``lrelu6``.
+    """:func:`leaky_relu6` can be used through its shortcut: :func:`tl.act.lrelu6`.
 
-    Modified version of PReLU Layer following the general idea of `ReLU6` introduced by the following paper:
+    This activation function is a modified version :func:`leaky_relu` introduced by the following paper:
+    `Rectifier Nonlinearities Improve Neural Network Acoustic Models [A. L. Maas et al., 2013] <https://ai.stanford.edu/~amaas/papers/relu_hybrid_icml2013_final.pdf>`__
 
-    - `Convolutional Deep Belief Networks on CIFAR-10 [A. Krizhevsky, 2010] <http://www.cs.utoronto.ca/~kriz/conv-cifar10-aug2010.pdf>`__
+    This activation function also follows the behaviour of the activation function :func:`tf.nn.relu6` introduced by the following paper:
+    `Convolutional Deep Belief Networks on CIFAR-10 [A. Krizhevsky, 2010] <http://www.cs.utoronto.ca/~kriz/conv-cifar10-aug2010.pdf>`__
+
+    The function return the following results:
+      - When x < 0: ``f(x) = alpha_low * x``.
+      - When x in [0, 6]: ``f(x) = x``.
+      - When x > 6: ``f(x) = 6``.
 
     Parameters
     ----------
@@ -102,13 +123,75 @@ def leaky_relu6(x, alpha=0.2, name="leaky_relu6"):
 
     References
     ----------
-    - `Rectifier Nonlinearities Improve Neural Network Acoustic Models, Maas et al. (2013) <http://web.stanford.edu/~awni/papers/relu_hybrid_icml2013_final.pdf>`__
-
+    - `Rectifier Nonlinearities Improve Neural Network Acoustic Models [A. L. Maas et al., 2013] <https://ai.stanford.edu/~amaas/papers/relu_hybrid_icml2013_final.pdf>`__
+    - `Convolutional Deep Belief Networks on CIFAR-10 [A. Krizhevsky, 2010] <http://www.cs.utoronto.ca/~kriz/conv-cifar10-aug2010.pdf>`__
     """
+
+    if not (0 < alpha <= 1):
+        raise ValueError("`alpha` value must be in [0, 1]`")
 
     with tf.name_scope(name, "leaky_relu6") as name_scope:
         x = tf.convert_to_tensor(x, name="features")
         return tf.minimum(tf.maximum(x, alpha * x), 6, name=name_scope)
+
+
+def leaky_twice_relu6(x, alpha_low=0.2, alpha_high=0.2, name="leaky_relu6"):
+    """:func:`leaky_twice_relu6` can be used through its shortcut: :func:`:func:`tl.act.ltrelu6`.
+
+    This activation function is a modified version :func:`leaky_relu` introduced by the following paper:
+    `Rectifier Nonlinearities Improve Neural Network Acoustic Models [A. L. Maas et al., 2013] <https://ai.stanford.edu/~amaas/papers/relu_hybrid_icml2013_final.pdf>`__
+
+    This activation function also follows the behaviour of the activation function :func:`tf.nn.relu6` introduced by the following paper:
+    `Convolutional Deep Belief Networks on CIFAR-10 [A. Krizhevsky, 2010] <http://www.cs.utoronto.ca/~kriz/conv-cifar10-aug2010.pdf>`__
+
+    This function push further the logic by adding `leaky` behaviour both below zero and above six.
+
+    The function return the following results:
+      - When x < 0: ``f(x) = alpha_low * x``.
+      - When x in [0, 6]: ``f(x) = x``.
+      - When x > 6: ``f(x) = 6 + (alpha_high * (x-6))``.
+
+    Parameters
+    ----------
+    x : Tensor
+        Support input type ``float``, ``double``, ``int32``, ``int64``, ``uint8``, ``int16``, or ``int8``.
+    alpha_low : float
+        Slope for x < 0: ``f(x) = alpha_low * x``.
+    alpha_high : float
+        Slope for x < 6: ``f(x) = 6 (alpha_high * (x-6))``.
+    name : str
+        The function name (optional).
+
+    Examples
+    --------
+    >>> import tensorlayer as tl
+    >>> net = tl.layers.DenseLayer(net, 100, act=lambda x : tl.act.leaky_twice_relu6(x, 0.2, 0.2), name='dense')
+
+    Returns
+    -------
+    Tensor
+        A ``Tensor`` in the same type as ``x``.
+
+    References
+    ----------
+    - `Rectifier Nonlinearities Improve Neural Network Acoustic Models [A. L. Maas et al., 2013] <https://ai.stanford.edu/~amaas/papers/relu_hybrid_icml2013_final.pdf>`__
+    - `Convolutional Deep Belief Networks on CIFAR-10 [A. Krizhevsky, 2010] <http://www.cs.utoronto.ca/~kriz/conv-cifar10-aug2010.pdf>`__
+
+    """
+
+    if not (0 < alpha_high <= 1):
+        raise ValueError("`alpha_high` value must be in [0, 1]`")
+
+    if not (0 < alpha_low <= 1):
+        raise ValueError("`alpha_low` value must be in [0, 1]`")
+
+    with tf.name_scope(name, "leaky_twice_relu6") as name_scope:
+        x = tf.convert_to_tensor(x, name="features")
+
+        x_is_above_0 = tf.minimum(x, 6 * (1 - alpha_high) + alpha_high * x)
+        x_is_below_0 = tf.minimum(alpha_low * x, 0)
+
+        return tf.maximum(x_is_above_0, x_is_below_0, name=name_scope)
 
 
 def swish(x, name='swish'):
@@ -255,4 +338,5 @@ def pixel_wise_softmax(x, name='pixel_wise_softmax'):
 # Alias
 lrelu = leaky_relu
 lrelu6 = leaky_relu6
+ltrelu6 = leaky_twice_relu6
 htanh = hard_tanh

--- a/tensorlayer/activation.py
+++ b/tensorlayer/activation.py
@@ -11,7 +11,6 @@ __all__ = [
     'swish',
     'sign',
     'pixel_wise_softmax',
-    'linear',
     'lrelu',
 ]
 
@@ -41,7 +40,7 @@ def ramp(x, v_min=0, v_max=1, name=None):
 
 @deprecated("2018-09-30", "This API is deprecated. Please use as `tf.nn.leaky_relu`.")
 def leaky_relu(x, alpha=0.2, name="leaky_relu"):
-    """LeakyReLU, Shortcut is ``lrelu``.
+    """LeakyReLU, shortcut is ``lrelu``.
 
     Modified version of ReLU, introducing a nonzero gradient for negative input.
 
@@ -66,21 +65,21 @@ def leaky_relu(x, alpha=0.2, name="leaky_relu"):
 
     References
     ----------
-    - `Rectifier Nonlinearities Improve Neural Network Acoustic Models, Maas et al. (2013)`
-       http://web.stanford.edu/~awni/papers/relu_hybrid_icml2013_final.pdf
+    - `Rectifier Nonlinearities Improve Neural Network Acoustic Models, Maas et al. (2013) <http://web.stanford.edu/~awni/papers/relu_hybrid_icml2013_final.pdf>`__
 
     """
+
     with tf.name_scope(name, "leaky_relu") as name_scope:
         x = tf.convert_to_tensor(x, name="features")
         return tf.maximum(x, alpha * x, name=name_scope)
 
 
 def leaky_relu6(x, alpha=0.2, name="leaky_relu6"):
-    """LeakyReLU6, Shortcut is ``lrelu6``.
+    """LeakyReLU6, shortcut is ``lrelu6``.
 
-    Modified version of Leaky ReLU following the general idea of `ReLU6` introduced by the following paper:
-        Convolutional Deep Belief Networks on CIFAR-10 [A. Krizhevsky, 2010]
-        http://www.cs.utoronto.ca/~kriz/conv-cifar10-aug2010.pdf
+    Modified version of PReLU Layer following the general idea of `ReLU6` introduced by the following paper:
+
+    - `Convolutional Deep Belief Networks on CIFAR-10 [A. Krizhevsky, 2010] <http://www.cs.utoronto.ca/~kriz/conv-cifar10-aug2010.pdf>`__
 
     Parameters
     ----------
@@ -100,6 +99,11 @@ def leaky_relu6(x, alpha=0.2, name="leaky_relu6"):
     -------
     Tensor
         A ``Tensor`` in the same type as ``x``.
+
+    References
+    ----------
+    - `Rectifier Nonlinearities Improve Neural Network Acoustic Models, Maas et al. (2013) <http://web.stanford.edu/~awni/papers/relu_hybrid_icml2013_final.pdf>`__
+
     """
 
     with tf.name_scope(name, "leaky_relu6") as name_scope:

--- a/tensorlayer/activation.py
+++ b/tensorlayer/activation.py
@@ -39,7 +39,8 @@ def ramp(x, v_min=0, v_max=1, name=None):
     return tf.clip_by_value(x, clip_value_min=v_min, clip_value_max=v_max, name=name)
 
 
-def leaky_relu(x, alpha=0.1, name="lrelu"):
+@deprecated("2018-09-30", "This API is deprecated. Please use as `tf.nn.leaky_relu`.")
+def leaky_relu(x, alpha=0.2, name="leaky_relu"):
     """LeakyReLU, Shortcut is ``lrelu``.
 
     Modified version of ReLU, introducing a nonzero gradient for negative input.
@@ -55,6 +56,7 @@ def leaky_relu(x, alpha=0.1, name="lrelu"):
 
     Examples
     --------
+    >>> import tensorlayer as tl
     >>> net = tl.layers.DenseLayer(net, 100, act=lambda x : tl.act.lrelu(x, 0.2), name='dense')
 
     Returns
@@ -68,12 +70,41 @@ def leaky_relu(x, alpha=0.1, name="lrelu"):
        http://web.stanford.edu/~awni/papers/relu_hybrid_icml2013_final.pdf
 
     """
-    # with tf.name_scope(name) as scope:
-    # x = tf.nn.relu(x)
-    # m_x = tf.nn.relu(-x)
-    # x -= alpha * m_x
-    x = tf.maximum(x, alpha * x, name=name)
-    return x
+    with tf.name_scope(name, "leaky_relu") as name_scope:
+        x = tf.convert_to_tensor(x, name="features")
+        return tf.maximum(x, alpha * x, name=name_scope)
+
+
+def leaky_relu6(x, alpha=0.2, name="leaky_relu6"):
+    """LeakyReLU6, Shortcut is ``lrelu6``.
+
+    Modified version of Leaky ReLU following the general idea of `ReLU6` introduced by the following paper:
+        Convolutional Deep Belief Networks on CIFAR-10 [A. Krizhevsky, 2010]
+        http://www.cs.utoronto.ca/~kriz/conv-cifar10-aug2010.pdf
+
+    Parameters
+    ----------
+    x : Tensor
+        Support input type ``float``, ``double``, ``int32``, ``int64``, ``uint8``, ``int16``, or ``int8``.
+    alpha : float
+        Slope.
+    name : str
+        The function name (optional).
+
+    Examples
+    --------
+    >>> import tensorlayer as tl
+    >>> net = tl.layers.DenseLayer(net, 100, act=lambda x : tl.act.leaky_relu6(x, 0.2), name='dense')
+
+    Returns
+    -------
+    Tensor
+        A ``Tensor`` in the same type as ``x``.
+    """
+
+    with tf.name_scope(name, "leaky_relu6") as name_scope:
+        x = tf.convert_to_tensor(x, name="features")
+        return tf.minimum(tf.maximum(x, alpha * x), 6, name=name_scope)
 
 
 def swish(x, name='swish'):
@@ -219,4 +250,5 @@ def pixel_wise_softmax(x, name='pixel_wise_softmax'):
 
 # Alias
 lrelu = leaky_relu
+lrelu6 = leaky_relu6
 htanh = hard_tanh

--- a/tensorlayer/cost.py
+++ b/tensorlayer/cost.py
@@ -31,8 +31,8 @@ __all__ = [
 
 
 def cross_entropy(output, target, name=None):
-    """Softmax cross-entropy operation, returns the TensorFlow expression of cross-entropy for two distributions, it implements
-    softmax internally. See ``tf.nn.sparse_softmax_cross_entropy_with_logits``.
+    """Softmax cross-entropy operation, returns the TensorFlow expression of cross-entropy for two distributions,
+    it implements softmax internally. See ``tf.nn.sparse_softmax_cross_entropy_with_logits``.
 
     Parameters
     ----------

--- a/tensorlayer/layers/padding.py
+++ b/tensorlayer/layers/padding.py
@@ -125,7 +125,8 @@ class ZeroPad2d(Layer):
         if not isinstance(padding, (int, tuple)):
             raise AssertionError("Padding should be of type `int` or `tuple`")
 
-        self.outputs = tf.keras.layers.ZeroPadding2D(padding=padding, name=name)(self.inputs)
+        self.outputs = tf.keras.layers.ZeroPadding2D(padding=padding, name=name)(self.inputs)  # TODO: Stop using Keras
+        
         self._add_layers(self.outputs)
 
 

--- a/tensorlayer/layers/padding.py
+++ b/tensorlayer/layers/padding.py
@@ -126,7 +126,7 @@ class ZeroPad2d(Layer):
             raise AssertionError("Padding should be of type `int` or `tuple`")
 
         self.outputs = tf.keras.layers.ZeroPadding2D(padding=padding, name=name)(self.inputs)  # TODO: Stop using Keras
-        
+
         self._add_layers(self.outputs)
 
 

--- a/tensorlayer/layers/special_activation.py
+++ b/tensorlayer/layers/special_activation.py
@@ -25,7 +25,7 @@ class PReluLayer(Layer):
     Parameters
     ----------
     prev_layer : :class:`Layer`
-        Previous layer。
+        Previous layer.
     channel_shared : boolean
         If True, single weight is shared by all channels.
     a_init : initializer
@@ -37,7 +37,7 @@ class PReluLayer(Layer):
 
     References
     -----------
-    - `Delving Deep into Rectifiers: Surpassing Human-Level Performance on ImageNet Classification <http://arxiv.org/pdf/1502.01852v1.pdf>`__
+    - `Delving Deep into Rectifiers: Surpassing Human-Level Performance on ImageNet Classification <http://arxiv.org/abs/1502.01852>`__
 
     """
 
@@ -73,13 +73,13 @@ class PRelu6Layer(Layer):
     The :class:`PRelu6Layer` class is Parametric Rectified Linear layer.
 
     Modified version of PReLU Layer following the general idea of `ReLU6` introduced by the following paper:
-        Convolutional Deep Belief Networks on CIFAR-10 [A. Krizhevsky, 2010]
-        http://www.cs.utoronto.ca/~kriz/conv-cifar10-aug2010.pdf
+
+    - `Convolutional Deep Belief Networks on CIFAR-10 [A. Krizhevsky, 2010] <http://www.cs.utoronto.ca/~kriz/conv-cifar10-aug2010.pdf>`__
 
     Parameters
     ----------
     prev_layer : :class:`Layer`
-        Previous layer。
+        Previous layer.
     channel_shared : boolean
         If True, single weight is shared by all channels.
     a_init : initializer
@@ -91,8 +91,7 @@ class PRelu6Layer(Layer):
 
     References
     -----------
-    - `Delving Deep into Rectifiers: Surpassing Human-Level Performance on ImageNet Classification
-       http://arxiv.org/abs/1502.01852
+    - `Delving Deep into Rectifiers: Surpassing Human-Level Performance on ImageNet Classification <http://arxiv.org/abs/1502.01852>`__
 
     """
 

--- a/tensorlayer/layers/special_activation.py
+++ b/tensorlayer/layers/special_activation.py
@@ -46,7 +46,7 @@ class PReluLayer(Layer):
 
     @deprecated_alias(layer='prev_layer', end_support_version=1.9)  # TODO remove this line for the 1.9 release
     def __init__(
-            self, prev_layer, channel_shared=False, a_init=tf.truncated_normal_initializer(mean=0.3, stddev=0.1),
+            self, prev_layer, channel_shared=False, a_init=tf.truncated_normal_initializer(mean=0.0, stddev=0.1),
             a_init_args=None, name="PReluLayer"
     ):
 
@@ -64,6 +64,8 @@ class PReluLayer(Layer):
             alpha_var = tf.get_variable(
                 name='alpha', shape=w_shape, initializer=a_init, dtype=LayersConfig.tf_dtype, **self.a_init_args
             )
+
+            alpha_var = tf.nn.sigmoid(alpha_var, name="constraining_alpha_var_in_0_1")
 
         self.outputs = tf.nn.leaky_relu(self.inputs, alpha=alpha_var, name="PReLU_activation")
 
@@ -113,7 +115,7 @@ class PRelu6Layer(Layer):
 
     @deprecated_alias(layer='prev_layer', end_support_version=1.9)  # TODO remove this line for the 1.9 release
     def __init__(
-            self, prev_layer, channel_shared=False, a_init=tf.truncated_normal_initializer(mean=0.3, stddev=0.1),
+            self, prev_layer, channel_shared=False, a_init=tf.truncated_normal_initializer(mean=0.0, stddev=0.1),
             a_init_args=None, name="PReLU6_layer"
     ):
 
@@ -131,6 +133,8 @@ class PRelu6Layer(Layer):
             alpha_var = tf.get_variable(
                 name='alpha', shape=w_shape, initializer=a_init, dtype=LayersConfig.tf_dtype, **self.a_init_args
             )
+            
+            alpha_var = tf.nn.sigmoid(alpha_var, name="constraining_alpha_var_in_0_1")
 
         self.outputs = leaky_relu6(self.inputs, alpha=alpha_var, name="PReLU6_activation")
 
@@ -182,7 +186,7 @@ class PTRelu6Layer(Layer):
 
     @deprecated_alias(layer='prev_layer', end_support_version=1.9)  # TODO remove this line for the 1.9 release
     def __init__(
-            self, prev_layer, channel_shared=False, a_init=tf.truncated_normal_initializer(mean=0.3, stddev=0.1),
+            self, prev_layer, channel_shared=False, a_init=tf.truncated_normal_initializer(mean=0.0, stddev=0.1),
             a_init_args=None, name="PTReLU6_layer"
     ):
 

--- a/tensorlayer/layers/special_activation.py
+++ b/tensorlayer/layers/special_activation.py
@@ -7,6 +7,7 @@ from tensorlayer.layers.core import Layer
 from tensorlayer.layers.core import LayersConfig
 
 from tensorlayer.activation import leaky_relu6
+from tensorlayer.activation import leaky_twice_relu6
 
 from tensorlayer import tl_logging as logging
 
@@ -15,6 +16,7 @@ from tensorlayer.decorators import deprecated_alias
 __all__ = [
     'PReluLayer',
     'PRelu6Layer',
+    'PTRelu6Layer',
 ]
 
 
@@ -38,13 +40,14 @@ class PReluLayer(Layer):
     References
     -----------
     - `Delving Deep into Rectifiers: Surpassing Human-Level Performance on ImageNet Classification <http://arxiv.org/abs/1502.01852>`__
+    - `Convolutional Deep Belief Networks on CIFAR-10 [A. Krizhevsky, 2010] <http://www.cs.utoronto.ca/~kriz/conv-cifar10-aug2010.pdf>`__
 
     """
 
     @deprecated_alias(layer='prev_layer', end_support_version=1.9)  # TODO remove this line for the 1.9 release
     def __init__(
-            self, prev_layer, channel_shared=False, a_init=tf.constant_initializer(value=0.2), a_init_args=None,
-            name="PReluLayer"
+            self, prev_layer, channel_shared=False, a_init=tf.truncated_normal_initializer(mean=0.3, stddev=0.1),
+            a_init_args=None, name="PReluLayer"
     ):
 
         super(PReluLayer, self).__init__(prev_layer=prev_layer, a_init_args=a_init_args, name=name)
@@ -70,11 +73,22 @@ class PReluLayer(Layer):
 
 class PRelu6Layer(Layer):
     """
-    The :class:`PRelu6Layer` class is Parametric Rectified Linear layer.
+    The :class:`PRelu6Layer` class is Parametric Rectified Linear layer integrating ReLU6 behaviour.
 
-    Modified version of PReLU Layer following the general idea of `ReLU6` introduced by the following paper:
+    This Layer is a modified version of the :class:`PReluLayer`.
 
-    - `Convolutional Deep Belief Networks on CIFAR-10 [A. Krizhevsky, 2010] <http://www.cs.utoronto.ca/~kriz/conv-cifar10-aug2010.pdf>`__
+    This activation layer use a modified version :func:`tl.act.leaky_relu` introduced by the following paper:
+    `Rectifier Nonlinearities Improve Neural Network Acoustic Models [A. L. Maas et al., 2013] <https://ai.stanford.edu/~amaas/papers/relu_hybrid_icml2013_final.pdf>`__
+
+    This activation function also use a modified version of the activation function :func:`tf.nn.relu6` introduced by the following paper:
+    `Convolutional Deep Belief Networks on CIFAR-10 [A. Krizhevsky, 2010] <http://www.cs.utoronto.ca/~kriz/conv-cifar10-aug2010.pdf>`__
+
+    This activation layer push further the logic by adding `leaky` behaviour both below zero and above six.
+
+    The function return the following results:
+      - When x < 0: ``f(x) = alpha_low * x``.
+      - When x in [0, 6]: ``f(x) = x``.
+      - When x > 6: ``f(x) = 6``.
 
     Parameters
     ----------
@@ -92,13 +106,15 @@ class PRelu6Layer(Layer):
     References
     -----------
     - `Delving Deep into Rectifiers: Surpassing Human-Level Performance on ImageNet Classification <http://arxiv.org/abs/1502.01852>`__
+    - `Rectifier Nonlinearities Improve Neural Network Acoustic Models [A. L. Maas et al., 2013] <https://ai.stanford.edu/~amaas/papers/relu_hybrid_icml2013_final.pdf>`__
+    - `Convolutional Deep Belief Networks on CIFAR-10 [A. Krizhevsky, 2010] <http://www.cs.utoronto.ca/~kriz/conv-cifar10-aug2010.pdf>`__
 
     """
 
     @deprecated_alias(layer='prev_layer', end_support_version=1.9)  # TODO remove this line for the 1.9 release
     def __init__(
-            self, prev_layer, channel_shared=False, a_init=tf.constant_initializer(value=0.2), a_init_args=None,
-            name="PReLU6_layer"
+            self, prev_layer, channel_shared=False, a_init=tf.truncated_normal_initializer(mean=0.3, stddev=0.1),
+            a_init_args=None, name="PReLU6_layer"
     ):
 
         super(PRelu6Layer, self).__init__(prev_layer=prev_layer, a_init_args=a_init_args, name=name)
@@ -120,3 +136,85 @@ class PRelu6Layer(Layer):
 
         self._add_layers(self.outputs)
         self._add_params(alpha_var)
+
+
+class PTRelu6Layer(Layer):
+    """
+    The :class:`PTRelu6Layer` class is Parametric Rectified Linear layer integrating ReLU6 behaviour.
+
+    This Layer is a modified version of the :class:`PReluLayer`.
+
+    This activation layer use a modified version :func:`tl.act.leaky_relu` introduced by the following paper:
+    `Rectifier Nonlinearities Improve Neural Network Acoustic Models [A. L. Maas et al., 2013] <https://ai.stanford.edu/~amaas/papers/relu_hybrid_icml2013_final.pdf>`__
+
+    This activation function also use a modified version of the activation function :func:`tf.nn.relu6` introduced by the following paper:
+    `Convolutional Deep Belief Networks on CIFAR-10 [A. Krizhevsky, 2010] <http://www.cs.utoronto.ca/~kriz/conv-cifar10-aug2010.pdf>`__
+
+    This activation layer push further the logic by adding `leaky` behaviour both below zero and above six.
+
+    The function return the following results:
+      - When x < 0: ``f(x) = alpha_low * x``.
+      - When x in [0, 6]: ``f(x) = x``.
+      - When x > 6: ``f(x) = 6 + (alpha_high * (x-6))``.
+
+    This version goes one step beyond :class:`PRelu6Layer` by introducing leaky behaviour on the positive side when x > 6.
+
+    Parameters
+    ----------
+    prev_layer : :class:`Layer`
+        Previous layer.
+    channel_shared : boolean
+        If True, single weight is shared by all channels.
+    a_init : initializer
+        The initializer for initializing the alpha(s).
+    a_init_args : dictionary
+        The arguments for initializing the alpha(s).
+    name : str
+        A unique layer name.
+
+    References
+    -----------
+    - `Delving Deep into Rectifiers: Surpassing Human-Level Performance on ImageNet Classification <http://arxiv.org/abs/1502.01852>`__
+    - `Convolutional Deep Belief Networks on CIFAR-10 [A. Krizhevsky, 2010] <http://www.cs.utoronto.ca/~kriz/conv-cifar10-aug2010.pdf>`__
+    - `Rectifier Nonlinearities Improve Neural Network Acoustic Models [A. L. Maas et al., 2013] <https://ai.stanford.edu/~amaas/papers/relu_hybrid_icml2013_final.pdf>`__
+
+    """
+
+    @deprecated_alias(layer='prev_layer', end_support_version=1.9)  # TODO remove this line for the 1.9 release
+    def __init__(
+            self, prev_layer, channel_shared=False, a_init=tf.truncated_normal_initializer(mean=0.3, stddev=0.1),
+            a_init_args=None, name="PTReLU6_layer"
+    ):
+
+        super(PTRelu6Layer, self).__init__(prev_layer=prev_layer, a_init_args=a_init_args, name=name)
+
+        if channel_shared:
+            w_shape = (1, )
+        else:
+            w_shape = int(self.inputs.get_shape()[-1])
+
+        logging.info("PTRelu6Layer %s: channel_shared: %s" % (self.name, channel_shared))
+
+        # with tf.name_scope(name) as scope:
+        with tf.variable_scope(name):
+
+            # Alpha for outputs lower than zeros
+            alpha_low = tf.get_variable(
+                name='alpha_low', shape=w_shape, initializer=a_init, dtype=LayersConfig.tf_dtype, **self.a_init_args
+            )
+
+            alpha_low = tf.nn.sigmoid(alpha_low, name="constraining_alpha_low_in_0_1")
+
+            # Alpha for outputs higher than 6
+            alpha_high = tf.get_variable(
+                name='alpha_high', shape=w_shape, initializer=a_init, dtype=LayersConfig.tf_dtype, **self.a_init_args
+            )
+
+            alpha_high = tf.nn.sigmoid(alpha_high, name="constraining_alpha_high_in_0_1")
+
+        self.outputs = leaky_twice_relu6(
+            self.inputs, alpha_low=alpha_low, alpha_high=alpha_high, name="PTReLU6_activation"
+        )
+
+        self._add_layers(self.outputs)
+        self._add_params([alpha_low, alpha_high])

--- a/tensorlayer/layers/special_activation.py
+++ b/tensorlayer/layers/special_activation.py
@@ -133,7 +133,7 @@ class PRelu6Layer(Layer):
             alpha_var = tf.get_variable(
                 name='alpha', shape=w_shape, initializer=a_init, dtype=LayersConfig.tf_dtype, **self.a_init_args
             )
-            
+
             alpha_var = tf.nn.sigmoid(alpha_var, name="constraining_alpha_var_in_0_1")
 
         self.outputs = leaky_relu6(self.inputs, alpha=alpha_var, name="PReLU6_activation")

--- a/tensorlayer/layers/special_activation.py
+++ b/tensorlayer/layers/special_activation.py
@@ -6,12 +6,15 @@ import tensorflow as tf
 from tensorlayer.layers.core import Layer
 from tensorlayer.layers.core import LayersConfig
 
+from tensorlayer.activation import leaky_relu6
+
 from tensorlayer import tl_logging as logging
 
 from tensorlayer.decorators import deprecated_alias
 
 __all__ = [
     'PReluLayer',
+    'PRelu6Layer',
 ]
 
 
@@ -40,8 +43,8 @@ class PReluLayer(Layer):
 
     @deprecated_alias(layer='prev_layer', end_support_version=1.9)  # TODO remove this line for the 1.9 release
     def __init__(
-            self, prev_layer, channel_shared=False, a_init=tf.constant_initializer(value=0.0), a_init_args=None,
-            name="prelu_layer"
+            self, prev_layer, channel_shared=False, a_init=tf.constant_initializer(value=0.2), a_init_args=None,
+            name="PReluLayer"
     ):
 
         super(PReluLayer, self).__init__(prev_layer=prev_layer, a_init_args=a_init_args, name=name)
@@ -55,11 +58,66 @@ class PReluLayer(Layer):
 
         # with tf.name_scope(name) as scope:
         with tf.variable_scope(name):
-            alphas = tf.get_variable(
-                name='alphas', shape=w_shape, initializer=a_init, dtype=LayersConfig.tf_dtype, **self.a_init_args
+            alpha_var = tf.get_variable(
+                name='alpha', shape=w_shape, initializer=a_init, dtype=LayersConfig.tf_dtype, **self.a_init_args
             )
 
-            self.outputs = tf.nn.relu(self.inputs) + tf.multiply(alphas, (self.inputs - tf.abs(self.inputs))) * 0.5
+        self.outputs = tf.nn.leaky_relu(self.inputs, alpha=alpha_var, name="PReLU_activation")
 
         self._add_layers(self.outputs)
-        self._add_params([alphas])
+        self._add_params(alpha_var)
+
+
+class PRelu6Layer(Layer):
+    """
+    The :class:`PRelu6Layer` class is Parametric Rectified Linear layer.
+
+    Modified version of PReLU Layer following the general idea of `ReLU6` introduced by the following paper:
+        Convolutional Deep Belief Networks on CIFAR-10 [A. Krizhevsky, 2010]
+        http://www.cs.utoronto.ca/~kriz/conv-cifar10-aug2010.pdf
+
+    Parameters
+    ----------
+    prev_layer : :class:`Layer`
+        Previous layer。
+    channel_shared : boolean
+        If True, single weight is shared by all channels.
+    a_init : initializer
+        The initializer for initializing the alpha(s).
+    a_init_args : dictionary
+        The arguments for initializing the alpha(s).
+    name : str
+        A unique layer name.
+
+    References
+    -----------
+    - `Delving Deep into Rectifiers: Surpassing Human-Level Performance on ImageNet Classification
+       http://arxiv.org/abs/1502.01852
+
+    """
+
+    @deprecated_alias(layer='prev_layer', end_support_version=1.9)  # TODO remove this line for the 1.9 release
+    def __init__(
+            self, prev_layer, channel_shared=False, a_init=tf.constant_initializer(value=0.2), a_init_args=None,
+            name="PReLU6_layer"
+    ):
+
+        super(PRelu6Layer, self).__init__(prev_layer=prev_layer, a_init_args=a_init_args, name=name)
+
+        if channel_shared:
+            w_shape = (1, )
+        else:
+            w_shape = int(self.inputs.get_shape()[-1])
+
+        logging.info("PRelu6Layer %s: channel_shared: %s" % (self.name, channel_shared))
+
+        # with tf.name_scope(name) as scope:
+        with tf.variable_scope(name):
+            alpha_var = tf.get_variable(
+                name='alpha', shape=w_shape, initializer=a_init, dtype=LayersConfig.tf_dtype, **self.a_init_args
+            )
+
+        self.outputs = leaky_relu6(self.inputs, alpha=alpha_var, name="PReLU6_activation")
+
+        self._add_layers(self.outputs)
+        self._add_params(alpha_var)

--- a/tests/test_activations.py
+++ b/tests/test_activations.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import unittest
+
+import tensorflow as tf
+import tensorlayer as tl
+
+import numpy as np
+
+try:
+    from tests.unittests_helper import CustomTestCase
+except ImportError:
+    from unittests_helper import CustomTestCase
+
+
+class Test_Leaky_ReLUs(CustomTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.alpha = 0.2
+
+        cls.input_var = tf.Variable(initial_value=0, dtype=tf.float32, name="Input_Var")
+
+        cls.lrelu_out = tl.act.leaky_relu(cls.input_var, alpha=cls.alpha)
+        cls.lrelu6_out = tl.act.leaky_relu6(cls.input_var, alpha=cls.alpha)
+        cls.ltrelu6_out = tl.act.leaky_twice_relu6(cls.input_var, alpha_low=cls.alpha, alpha_high=cls.alpha)
+
+        cls.sess = tf.Session()
+        cls.sess.run(tf.global_variables_initializer())
+
+    @classmethod
+    def tearDownClass(cls):
+        tf.reset_default_graph()
+
+    def test_lrelu(self):
+        for i in range(-5, 15):
+
+            if i > 0:
+                good_output = i
+            else:
+                good_output = self.alpha * i
+
+            computed_output = self.sess.run(self.lrelu_out, feed_dict={self.input_var: i})
+
+            self.assertAlmostEqual(computed_output, good_output, places=5)
+
+    def test_lrelu6(self):
+        for i in range(-5, 15):
+
+            if i < 0:
+                good_output = self.alpha * i
+            else:
+                good_output = min(6, i)
+
+            computed_output = self.sess.run(self.lrelu6_out, feed_dict={self.input_var: i})
+
+            self.assertAlmostEqual(computed_output, good_output, places=5)
+
+    def test_ltrelu6(self):
+        for i in range(-5, 15):
+
+            if i < 0:
+                good_output = self.alpha * i
+            elif i < 6:
+                good_output = i
+            else:
+                good_output = 6 + (self.alpha * (i - 6))
+
+            computed_output = self.sess.run(self.ltrelu6_out, feed_dict={self.input_var: i})
+
+            self.assertAlmostEqual(computed_output, good_output, places=5)
+
+
+if __name__ == '__main__':
+
+    tf.logging.set_verbosity(tf.logging.DEBUG)
+    tl.logging.set_verbosity(tl.logging.DEBUG)
+
+    unittest.main()

--- a/tests/test_activations.py
+++ b/tests/test_activations.py
@@ -5,8 +5,6 @@ import unittest
 import tensorflow as tf
 import tensorlayer as tl
 
-import numpy as np
-
 try:
     from tests.unittests_helper import CustomTestCase
 except ImportError:


### PR DESCRIPTION
- `tl.act.leaky_relu` deprecated in favor of `tf.nn.leaky_relu`
- following the idea of `tf.nn.relu6`, I have implemented `tl.act.leaky_relu6` and `tl.layers.PReLU6Layer`.

I also have simplified the computation of `tl.layers.PReLULayer`