### PR TITLE
unicode() --> six.text_type() for Python 3

### DIFF
--- a/tests/test_yapf_format.py
+++ b/tests/test_yapf_format.py
@@ -4,6 +4,8 @@
 import sys
 import unittest
 
+from six import text_type
+
 try:
     import tests.testing as testing
     from tests.unittests_helper import CustomTestCase
@@ -17,7 +19,7 @@ from yapf.yapflib.yapf_api import FormatCode
 def _read_utf_8_file(filename):
     if sys.version_info.major == 2:  ## Python 2 specific
         with open(filename, 'rb') as f:
-            return unicode(f.read(), 'utf-8')
+            return text_type(f.read(), 'utf-8')
     else:
         with open(filename, encoding='utf-8') as f:
             return f.read()


### PR DESCRIPTION
__unicode()__ was removed in Python 3 because all __str__ are Unicode so replace with __six.text_type()__.

<!-- ============================================================================================================
Thanks for contributing to _TensorLayer_! We really appreciate your help !
Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] 
============================================================================================================= -->

### Checklist
- [ ] I've tested that my changes are compatible with the latest version of Tensorflow.
- [ ] I've read the [Contribution Guidelines](https://github.com/tensorlayer/tensorlayer/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->
