### PR TITLE
URL Encoding Fix for PyPI in Chinese Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 [![Mentioned in Awesome TensorLayer](https://awesome.re/mentioned-badge.svg)](https://github.com/tensorlayer/awesome-tensorlayer)
 [![English Documentation](https://img.shields.io/badge/documentation-english-blue.svg)](https://tensorlayer.readthedocs.io/)
-[![Chinese Documentation](https://img.shields.io/badge/documentation-中文-blue.svg)](https://tensorlayercn.readthedocs.io/)
-[![Chinese Book](https://img.shields.io/badge/book-中文-blue.svg)](http://www.broadview.com.cn/book/5059/)
+[![Chinese Documentation](https://img.shields.io/badge/documentation-%E4%B8%AD%E6%96%87-blue.svg)](https://tensorlayercn.readthedocs.io/)
+[![Chinese Book](https://img.shields.io/badge/book-%E4%B8%AD%E6%96%87-blue.svg)](http://www.broadview.com.cn/book/5059/)
 [![Downloads](http://pepy.tech/badge/tensorlayer)](http://pepy.tech/project/tensorlayer)
 
 

--- a/README.rst
+++ b/README.rst
@@ -162,9 +162,9 @@ TensorLayer is released under the Apache 2.0 license.
    :target: https://github.com/tensorlayer/awesome-tensorlayer
 .. |Documentation-EN| image:: https://img.shields.io/badge/documentation-english-blue.svg
    :target: https://tensorlayer.readthedocs.io/
-.. |Documentation-CN| image:: https://img.shields.io/badge/documentation-中文-blue.svg
+.. |Documentation-CN| image:: https://img.shields.io/badge/documentation-%E4%B8%AD%E6%96%87-blue.svg
    :target: https://tensorlayercn.readthedocs.io/
-.. |Book-CN| image:: https://img.shields.io/badge/book-中文-blue.svg
+.. |Book-CN| image:: https://img.shields.io/badge/book-%E4%B8%AD%E6%96%87-blue.svg
    :target: http://www.broadview.com.cn/book/5059/
 .. |Downloads| image:: http://pepy.tech/badge/tensorlayer
    :target: http://pepy.tech/project/tensorlayer


### PR DESCRIPTION
I suspect that the URL encoding for UTF-8 chars is not supported on PyPI, leading to this behavior:

https://pypi.org/project/tensorlayer/

![image](https://user-images.githubusercontent.com/10923599/42122632-ec246840-7c44-11e8-9370-c15b21cd289e.png)

This PR should fix this for the next release ;)

Please merge, no need to update the changelog ;)