### PR TITLE
cache pip for faster CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 # https://docs.travis-ci.com/user/languages/python/
 language: python
 
+# https://docs.travis-ci.com/user/caching/#pip-cache
+cache: pip
+
 addons:
   apt:
     update: false


### PR DESCRIPTION
Currently `pip install` takes about 90s out of 3m30s per build.