### PR TITLE
Remove private_method decorator (issue #1024)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ To release a new version, please update the changelog as followed:
 - Fix `tf.models.Model._construct_graph` for list of outputs, e.g. STN case (PR #1010)
 - Enable better `in_channels` exception raise. (pR #1015)
 - Set allow_pickle=True in np.load() (#PR 1021)
+- Remove `private_method` decorator (#PR 1025)
 
 ### Removed
 
@@ -116,7 +117,7 @@ To release a new version, please update the changelog as followed:
 ### Contributors
 
 - @zsdonghao
-- @ChrisWu1997: #1010 #1015
+- @ChrisWu1997: #1010 #1015 #1025
 - @warshallrho: #1017 #1021
 - @ArnoldLIULJ: #1023
 - @JingqingZ: #1023

--- a/tensorlayer/layers/convolution/deformable_conv.py
+++ b/tensorlayer/layers/convolution/deformable_conv.py
@@ -235,26 +235,22 @@ class DeformableConv2d(Layer):
             outputs = self.act(outputs)
         return outputs
 
-    @private_method
     def _to_bc_h_w(self, x, x_shape):
         """(b, h, w, c) -> (b*c, h, w)"""
         x = tf.transpose(a=x, perm=[0, 3, 1, 2])
         x = tf.reshape(x, (-1, x_shape[1], x_shape[2]))
         return x
 
-    @private_method
     def _to_b_h_w_n_c(self, x, x_shape):
         """(b*c, h, w, n) -> (b, h, w, n, c)"""
         x = tf.reshape(x, (-1, x_shape[4], x_shape[1], x_shape[2], x_shape[3]))
         x = tf.transpose(a=x, perm=[0, 2, 3, 4, 1])
         return x
 
-    @private_method
     def tf_flatten(self, a):
         """Flatten tensor"""
         return tf.reshape(a, [-1])
 
-    @private_method
     def _get_vals_by_coords(self, inputs, coords, idx, out_shape):
         indices = tf.stack(
             [idx, self.tf_flatten(coords[:, :, :, :, 0]),
@@ -264,7 +260,6 @@ class DeformableConv2d(Layer):
         vals = tf.reshape(vals, out_shape)
         return vals
 
-    @private_method
     def _tf_repeat(self, a, repeats):
         """Tensorflow version of np.repeat for 1D"""
         # https://github.com/tensorflow/tensorflow/issues/8521
@@ -277,7 +272,6 @@ class DeformableConv2d(Layer):
         a = self.tf_flatten(a)
         return a
 
-    @private_method
     def _tf_batch_map_coordinates(self, inputs, coords):
         """Batch version of tf_map_coordinates
 
@@ -324,7 +318,6 @@ class DeformableConv2d(Layer):
 
         return mapped_vals
 
-    @private_method
     def _tf_batch_map_offsets(self, inputs, offsets, grid_offset):
         """Batch map offsets into input
 

--- a/tensorlayer/layers/convolution/super_resolution.py
+++ b/tensorlayer/layers/convolution/super_resolution.py
@@ -87,7 +87,6 @@ class SubpixelConv1d(Layer):
             outputs = self.act(outputs)
         return outputs
 
-    @private_method
     def _PS(self, I, r):
         X = tf.transpose(a=I, perm=[2, 1, 0])  # (r, w, b)
         X = tf.batch_to_space(input=X, block_shape=[r], crops=[[0, 0]])  # (1, r*w, b)

--- a/tensorlayer/layers/convolution/super_resolution.py
+++ b/tensorlayer/layers/convolution/super_resolution.py
@@ -188,7 +188,6 @@ class SubpixelConv2d(Layer):
             outputs = self.act(outputs)
         return outputs
 
-    @private_method
     def _PS(self, X, r, n_out_channels):
 
         _err_log = "SubpixelConv2d: The number of input channels == (scale x scale) x The number of output channels"


### PR DESCRIPTION
<!-- ============================================================================================================
Thanks for contributing to _TensorLayer_! We really appreciate your help !
Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] 
============================================================================================================= -->

### Checklist
- [x] I've tested that my changes are compatible with the latest version of Tensorflow.
- [x] I've read the [Contribution Guidelines](https://github.com/tensorlayer/tensorlayer/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fix issue #1024 as `private_method` decorator is found incompatible with `tf.function`.

### Description
Remove `@private_method` decorator for super pixel conv.