### PR TITLE
replace tf.image.resize_image_with_crop_or_pad with tf.image.resize_with_crop_or_pad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,8 @@ To release a new version, please update the changelog as followed:
 - Remove `private_method` decorator (#PR 1025)
 - Copy original model's `trainable_weights` and `nontrainable_weights` when initializing `ModelLayer` (#PR 1026)
 - Copy original model's `trainable_weights` and `nontrainable_weights` when initializing `LayerList` (#PR 1029)
-- remove redundant parts in `model.all_layers` (#PR 1029)
+- Remove redundant parts in `model.all_layers` (#PR 1029)
+- Replace `tf.image.resize_image_with_crop_or_pad` with `tf.image.resize_with_crop_or_pad` (#PR 1032)
 
 ### Removed
 
@@ -122,7 +123,7 @@ To release a new version, please update the changelog as followed:
 
 - @zsdonghao
 - @ChrisWu1997: #1010 #1015 #1025 #1030
-- @warshallrho: #1017 #1021 #1026 #1029
+- @warshallrho: #1017 #1021 #1026 #1029 #1032
 - @ArnoldLIULJ: #1023
 - @JingqingZ: #1023
 

--- a/examples/basic_tutorials/tutorial_cifar10_cnn_static.py
+++ b/examples/basic_tutorials/tutorial_cifar10_cnn_static.py
@@ -127,7 +127,7 @@ def _map_fn_train(img, target):
 
 def _map_fn_test(img, target):
     # 1. Crop the central [height, width] of the image.
-    img = tf.image.resize_image_with_crop_or_pad(img, 24, 24)
+    img = tf.image.resize_with_crop_or_pad(img, 24, 24)
     # 2. Subtract off the mean and divide by the variance of the pixels.
     img = tf.image.per_image_standardization(img)
     img = tf.reshape(img, (24, 24, 3))


### PR DESCRIPTION
…ith_crop_or_pad

tf.image.resize_image_with_crop_or_pad is not supported now

<!-- ============================================================================================================
Thanks for contributing to _TensorLayer_! We really appreciate your help !
Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] 
============================================================================================================= -->

### Checklist
- [x] I've tested that my changes are compatible with the latest version of Tensorflow.
- [x] I've read the [Contribution Guidelines](https://github.com/tensorlayer/tensorlayer/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

### Description
<!--- Describe your changes in detail -->
tf.image.resize_image_with_crop_or_pad is not supported now
