### PR TITLE
docs: fix simple typo, determinstic -> deterministic

### DIFF
--- a/examples/reinforcement_learning/tutorial_SAC.py
+++ b/examples/reinforcement_learning/tutorial_SAC.py
@@ -138,7 +138,7 @@ class SoftQNetwork(Model):
 
 
 class PolicyNetwork(Model):
-    """ the network for generating non-determinstic (Gaussian distributed) action from the state input """
+    """ the network for generating non-deterministic (Gaussian distributed) action from the state input """
 
     def __init__(
             self, num_inputs, num_actions, hidden_dim, action_range=1., init_w=3e-3, log_std_min=-20, log_std_max=2

--- a/examples/reinforcement_learning/tutorial_TD3.py
+++ b/examples/reinforcement_learning/tutorial_TD3.py
@@ -148,7 +148,7 @@ class QNetwork(Model):
 
 
 class PolicyNetwork(Model):
-    """ the network for generating non-determinstic (Gaussian distributed) action from the state input """
+    """ the network for generating non-deterministic (Gaussian distributed) action from the state input """
 
     def __init__(self, num_inputs, num_actions, hidden_dim, action_range=1., init_w=3e-3):
         super(PolicyNetwork, self).__init__()


### PR DESCRIPTION
There is a small typo in examples/reinforcement_learning/tutorial_SAC.py, examples/reinforcement_learning/tutorial_TD3.py.

Should read `deterministic` rather than `determinstic`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md