### PR TITLE
Fix inconsistent output in zoom_multi

### DIFF
--- a/tensorlayer/prepro.py
+++ b/tensorlayer/prepro.py
@@ -1527,7 +1527,7 @@ def zoom_multi(x, zoom_range=(0.9, 1.1), flags=None, border_mode='constant'):
         h, w = x.shape[0], x.shape[1]
         transform_matrix = transform_matrix_offset_center(zoom_matrix, h, w)
         results.append(affine_transform_cv2(x, transform_matrix, flags=flags, border_mode=border_mode))
-    return results
+    return np.asarray(results)
 
 
 # image = tf.image.random_brightness(image, max_delta=32. / 255.)


### PR DESCRIPTION
### Checklist
- [x] I've tested that my changes are compatible with the latest version of Tensorflow.
- [x] I've read the [Contribution Guidelines](https://github.com/tensorlayer/tensorlayer/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Preprocessing tools of the type `*_multi` (eg. `elastic_transform_multi`, `swirl_multi`, etc) accept a numpy array as input and return a numpy array as output. On the contrary, `zoom_multi` accepts an array as input but returns a list of arrays, which seems inconsistent with the other functions in addition to disagree with the docstrings, which says that the return value is a numpy array. 

### Description
I just use `np.asarray` to transform the list to an array, as it is done in the other `*_multi` functions. 
